### PR TITLE
Bump version to 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - **NEW**: Allow definition of custom search engines that are triggered by custom alias
   - New option: `customSearchEngines`, with one default entry: `g ` for executing a google search.
+  - Also added `blank` option when no search string is given
+  - Allowing for multiple aliases, if defined as an array (`['alias1', 'alias`]`)
 
 ## [v1.7.0]
 

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -3,7 +3,7 @@
   "description": "Browser extension to (fuzzy) search and navigate bookmarks, history and open tabs.",
   "homepage_url": "https://github.com/Fannon/search-bookmarks-history-and-tabs",
   "author": "Simon Heimler",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "manifest_version": 2,
   "applications": {
     "gecko": {

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "description": "Browser extension to (fuzzy) search and navigate bookmarks, history and open tabs.",
   "homepage_url": "https://github.com/Fannon/search-bookmarks-history-and-tabs",
   "author": "Simon Heimler",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "manifest_version": 3,
   "permissions": ["tabs", "bookmarks", "history", "storage"],
   "action": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "search-bookmarks-history-and-tabs",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "search-bookmarks-history-and-tabs",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@leeoniya/ufuzzy": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "search-bookmarks-history-and-tabs",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Browser extension to (fuzzy) search and navigate bookmarks, history and open tabs.",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
## [v1.8.0]

- **NEW**: Allow definition of custom search engines that are triggered by custom alias
  - New option: `customSearchEngines`, with one default entry: `g ` for executing a google search.
  - Also added `blank` option when no search string is given
  - Allowing for multiple aliases, if defined as an array (`['alias1', 'alias`]`)