### PR TITLE
Prevent ArrowUp key jump to input beginning

### DIFF
--- a/popup/js/view/searchView.js
+++ b/popup/js/view/searchView.js
@@ -179,8 +179,11 @@ export function renderSearchResults(result) {
  * -> Arrow up, Arrow Down, Enter
  */
 export function navigationKeyListener(event) {
-  if (event.key === 'ArrowUp' && ext.model.currentItem > 0) {
+  if (event.key === 'ArrowUp' && ext.dom.searchInput.value && ext.model.currentItem == 0) {
+    event.preventDefault()
+  } else if (event.key === 'ArrowUp' && ext.model.currentItem > 0) {
     ext.model.currentItem--
+    event.preventDefault()
     selectListItem(ext.model.currentItem, true)
   } else if (event.key === 'ArrowDown' && ext.model.currentItem < ext.model.result.length - 1) {
     ext.model.currentItem++


### PR DESCRIPTION
**Hi maintainer:**

I make a pull request here for:

- Why?
Both Chrom and Firefox bind `Up` and `Down` arrow key making text focus cursor fast forward to beginning and end of the focused search box respectively; Those feature is very annoying for daily using, espesially when we choosing item via scrolling up and down while just using keyboard but still rely on continuous inputs for modifcation or increamently fuzzy searching where we'll always need to repair the moved input cursor position caused by thus.

- Thus:
Thus I made this workaround for banning that way just for the arrow up key since the down key always moving cursor to end of inputs which is rarely need for treating for as (if need for adding so, I also can do for that later, but for this time I just try this as rice). The idea is inspired by [here](https://stackoverflow.com/questions/1080532/prevent-default-behavior-in-text-input-while-pressing-arrow-up).

- But:
I'm a newbie for JS so that any improvement suggestions and discussions are welcom and grateful.

**Finally**

Thanks for you to create this amazing web-extension which gives the browser has ability like a riched text editor :)