### PR TITLE
Display full URL when hovering over it (HTML title attribute)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [v1.8.4]
+
+- **NEW**: When hovering over an URL, the full URL is displayed as a hover. Requested via [#74](https://github.com/Fannon/search-bookmarks-history-and-tabs/issues/74)
+- **IMPROVED**: Updated dependencies
+
 ## [v1.8.3]
 
 - **FIXED**: When navigating result items via arrow up, the search text input box curser moved to the beginning of the search string

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -3,7 +3,7 @@
   "description": "Browser extension to (fuzzy) search and navigate bookmarks, history and open tabs.",
   "homepage_url": "https://github.com/Fannon/search-bookmarks-history-and-tabs",
   "author": "Simon Heimler",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "manifest_version": 2,
   "applications": {
     "gecko": {

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "description": "Browser extension to (fuzzy) search and navigate bookmarks, history and open tabs.",
   "homepage_url": "https://github.com/Fannon/search-bookmarks-history-and-tabs",
   "author": "Simon Heimler",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "manifest_version": 3,
   "permissions": ["tabs", "bookmarks", "history", "storage"],
   "action": {

--- a/popup/js/view/searchView.js
+++ b/popup/js/view/searchView.js
@@ -131,6 +131,7 @@ export function renderSearchResults(result) {
     // Create URL div
     const urlDiv = document.createElement('div')
     urlDiv.classList.add('url')
+    urlDiv.title = resultEntry.url
     if (
       ext.opts.displaySearchMatchHighlight &&
       resultEntry.urlHighlighted &&


### PR DESCRIPTION
- **NEW**: When hovering over an URL, the full URL is displayed as a hover. Requested via [#74](https://github.com/Fannon/search-bookmarks-history-and-tabs/issues/74)

Relates #74 