### PR TITLE
Add uFuzzy user customizable option: `ufuzzyOptions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ customSearchEngines:
 ```
 
 In case of making multilingual searching correctly, you may need to tweak [uFuzzy](https://github.com/leeoniya/uFuzzy) options via option `ufuzzyOptions`, for example:
+
 ```yaml
 # make CJK chars can be searched
 ufuzzyOptions:

--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ customSearchEngines:
     blank: https://www.npmjs.com
 ```
 
+In case of making multilingual searching correctly, you may need to tweak [uFuzzy](https://github.com/leeoniya/uFuzzy) options via option `ufuzzyOptions`, for example:
+```yaml
+# make CJK chars can be searched
+ufuzzyOptions:
+  - interSplit: (p{Unified_Ideograph=yes})+
+```
+
 ## Scoring System
 
 The scoring systems works roughly the following:

--- a/popup/js/model/options.js
+++ b/popup/js/model/options.js
@@ -55,6 +55,13 @@ export const defaultOptions = {
    */
   searchFuzzyness: 0.6,
 
+  /**
+   * Customized options for uFuzzy ('@leeoniya/ufuzzy') defaults and
+   * our builtin specifications. (See also
+   * https://github.com/leeoniya/uFuzzy/blob/main/src/uFuzzy.js#L9)
+   */
+  ufuzzyOptions: [],
+
   //////////////////////////////////////////
   // COLORS AND STYLE                     //
   //////////////////////////////////////////

--- a/popup/js/search/fuzzySearch.js
+++ b/popup/js/search/fuzzySearch.js
@@ -64,6 +64,15 @@ function fuzzySearchWithScoring(searchTerm, searchMode) {
       options.intraDel = 1 // deletion (omission)
     }
 
+    // Respect user specifications
+    if (ext.opts.ufuzzyOptions) {
+      for (let i = 0; i < ext.opts.ufuzzyOptions.length; i++) {
+        for (let key in ext.opts.ufuzzyOptions[i]) {
+          options[key] = ext.opts.ufuzzyOptions[i][key]
+        }
+      }
+    }
+
     state[searchMode] = {
       haystack: data.map((el) => {
         return el.searchString


### PR DESCRIPTION
Issued by #87, we should provide this to let multilingual searching be capable, robust and following user side specifications via doing more tweaks of uFuzzy(@leeoniya/ufuzzy).

See also:
- https://github.com/leeoniya/uFuzzy/issues/14
- https://github.com/leeoniya/uFuzzy#how-it-works