### PR TITLE
Fix bug of option `tabsDisplayLastVisited` for firefox

### DIFF
--- a/popup/js/helper/browserApi.js
+++ b/popup/js/helper/browserApi.js
@@ -41,10 +41,8 @@ export function convertBrowserTabs(chromeTabs) {
       active: entry.active,
       windowId: entry.windowId,
       searchString: createSearchString(entry.title, cleanUrl),
-      lastVisitSecondsAgo: entry.lastAccessed
-        ? (Date.now() - entry.lastAccessed) / 1000 : undefined,
-      lastVisit: (entry.lastAccessed && ext.opts.displayLastVisit)
-        ? timeSince(new Date(entry.lastAccessed)) : undefined
+      lastVisitSecondsAgo: entry.lastAccessed ? (Date.now() - entry.lastAccessed) / 1000 : undefined,
+      lastVisit: entry.lastAccessed && ext.opts.displayLastVisit ? timeSince(new Date(entry.lastAccessed)) : undefined,
     }
   })
 }

--- a/popup/js/helper/browserApi.js
+++ b/popup/js/helper/browserApi.js
@@ -41,6 +41,10 @@ export function convertBrowserTabs(chromeTabs) {
       active: entry.active,
       windowId: entry.windowId,
       searchString: createSearchString(entry.title, cleanUrl),
+      lastVisitSecondsAgo: entry.lastAccessed
+        ? (Date.now() - entry.lastAccessed) / 1000 : undefined,
+      lastVisit: (entry.lastAccessed && ext.opts.displayLastVisit)
+        ? timeSince(new Date(entry.lastAccessed)) : undefined
     }
   })
 }


### PR DESCRIPTION
Bug description:

```
No visited tabs listed while `tabsDisplayLastVisited` is true but
`enableHistory` is disabled.
```

Reason:

The function `convertBrowserTabs` returns object without keys of
`lastVisit` and `lastVisitSecondsAgo` defined, but they are required
by the `sort` calculation of `lastVisitedTabs` used in top-level
function `addDefaultEntries`.

> **And why this bug doesn't occur when `enableHistory` is enabled?**
>
> Since top-level function `getSearchData` defaultly merging history
> into open tabs, and history always includes the visited tabs entries
> whose `lastVisit` and `lastVisitSecondsAgo` is already calculated in
> function `convertBrowserHistory`.

Fix:

This commit fix this bug by adding the missing keys to
`convertBrowserTabs` just for firfox since I can not found the
equivalent API (tab.lastAccessed) for chromium based browsers.
