### PR TITLE
Support non-ASCII characters in fuzzy search

### DIFF
--- a/cypress/e2e/search.cy.js
+++ b/cypress/e2e/search.cy.js
@@ -113,6 +113,25 @@ describe('Search View', () => {
         .find('li.bookmark')
         .checkNoErrors()
     })
+    it('can execute a precise search with non-ASCII chars successfully', () => {
+      cy.get('#search-approach-toggle')
+        .get('#search-input')
+        .type(`äe指事字₽`)
+        .wait(initTime)
+        // Make sure we get result of all types
+        .get('#result-list')
+        .should('not.have.length', 0)
+        .find('[x-original-id=9]')
+        .get('#result-list')
+        .find('li.bookmark')
+        .get('#result-list')
+        .find('li.history')
+        .get('#result-list')
+        .find('li.tab')
+        .get('#result-list')
+        .find('li.bookmark')
+        .checkNoErrors()
+    })
   })
 
   describe('Fuzzy search', () => {

--- a/cypress/e2e/search.cy.js
+++ b/cypress/e2e/search.cy.js
@@ -118,18 +118,9 @@ describe('Search View', () => {
         .get('#search-input')
         .type(`äe指事字₽`)
         .wait(initTime)
-        // Make sure we get result of all types
+        // Only make sure that search doesn't crash
         .get('#result-list')
         .should('not.have.length', 0)
-        .find('[x-original-id=9]')
-        .get('#result-list')
-        .find('li.bookmark')
-        .get('#result-list')
-        .find('li.history')
-        .get('#result-list')
-        .find('li.tab')
-        .get('#result-list')
-        .find('li.bookmark')
         .checkNoErrors()
     })
   })
@@ -173,6 +164,23 @@ describe('Search View', () => {
         .find('li.bookmark')
         .checkNoErrors()
     })
+  })
+
+  it('can execute a precise search with non-ASCII chars successfully', () => {
+    cy.get('#search-approach-toggle')
+      .wait(interactionTime)
+      .contains('PRECISE')
+      .click()
+      .wait(interactionTime)
+      .contains('FUZZY')
+      .wait(interactionTime)
+      .get('#search-input')
+      .type(`äe指事字₽`)
+      .wait(initTime)
+      // Only make sure that search doesn't crash
+      .get('#result-list')
+      .should('not.have.length', 0)
+      .checkNoErrors()
   })
 
   describe('Hybrid search', () => {


### PR DESCRIPTION
This PR will fix fuzzy search crashing without good error message if non ASCII chars are used (e.g. CJK characters). 
It will check the search string and if it contains a non ASCII char, it will apply the `interSplit: (p{Unified_Ideograph=yes})+` option automatically as suggested by @ojarux 

Fixes #94 