### PR TITLE
Fix bug with bookmark tagging (update to fixed dependency)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "@leeoniya/ufuzzy": "^1.0.14",
-        "@yaireo/tagify": "^4.31.0",
+        "@yaireo/tagify": "^4.31.3",
         "js-yaml": "^4.1.0",
         "mark.js": "^8.11.1",
         "minireset.css": "^0.0.7"
       },
       "devDependencies": {
-        "cypress": "^13.13.3",
+        "cypress": "^13.14.1",
         "cypress-fail-on-console-error": "^5.1.1",
         "eslint": "^9.9.1",
         "eslint-plugin-cypress": "^3.5.0",
@@ -316,10 +316,9 @@
       }
     },
     "node_modules/@yaireo/tagify": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@yaireo/tagify/-/tagify-4.31.0.tgz",
-      "integrity": "sha512-om1HsHCbcI7REKRVNpe+V0SIhInZxcf9jZSPaHCnnpBgBS3ZbTVs9sXReGC55WxLLEoXtOQWMJSDrzefxKretQ==",
-      "license": "MIT",
+      "version": "4.31.3",
+      "resolved": "https://registry.npmjs.org/@yaireo/tagify/-/tagify-4.31.3.tgz",
+      "integrity": "sha512-YpBvYxqkJkOGyHg+0OzTCgt8Zb4vlYq+qE7jgxBLyPrvheSI0SXj3dbc4lVhCQhtbos4Kb2+t7ou8a+LYQk0Og==",
       "engines": {
         "node": ">=16.15.0",
         "npm": ">=9.0.0"
@@ -1236,12 +1235,11 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.13.3",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.3.tgz",
-      "integrity": "sha512-hUxPrdbJXhUOTzuML+y9Av7CKoYznbD83pt8g3klgpioEha0emfx4WNIuVRx0C76r0xV2MIwAW9WYiXfVJYFQw==",
+      "version": "13.14.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.14.1.tgz",
+      "integrity": "sha512-Wo+byPmjps66hACEH5udhXINEiN3qS3jWNGRzJOjrRJF3D0+YrcP2LVB1T7oYaVQM/S+eanqEvBWYc8cf7Vcbg==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@cypress/request": "^3.0.1",
         "@cypress/xvfb": "^1.2.4",
@@ -5907,9 +5905,9 @@
       }
     },
     "@yaireo/tagify": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@yaireo/tagify/-/tagify-4.31.0.tgz",
-      "integrity": "sha512-om1HsHCbcI7REKRVNpe+V0SIhInZxcf9jZSPaHCnnpBgBS3ZbTVs9sXReGC55WxLLEoXtOQWMJSDrzefxKretQ==",
+      "version": "4.31.3",
+      "resolved": "https://registry.npmjs.org/@yaireo/tagify/-/tagify-4.31.3.tgz",
+      "integrity": "sha512-YpBvYxqkJkOGyHg+0OzTCgt8Zb4vlYq+qE7jgxBLyPrvheSI0SXj3dbc4lVhCQhtbos4Kb2+t7ou8a+LYQk0Og==",
       "requires": {}
     },
     "accepts": {
@@ -6588,9 +6586,9 @@
       }
     },
     "cypress": {
-      "version": "13.13.3",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.3.tgz",
-      "integrity": "sha512-hUxPrdbJXhUOTzuML+y9Av7CKoYznbD83pt8g3klgpioEha0emfx4WNIuVRx0C76r0xV2MIwAW9WYiXfVJYFQw==",
+      "version": "13.14.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.14.1.tgz",
+      "integrity": "sha512-Wo+byPmjps66hACEH5udhXINEiN3qS3jWNGRzJOjrRJF3D0+YrcP2LVB1T7oYaVQM/S+eanqEvBWYc8cf7Vcbg==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "type": "module",
   "dependencies": {
     "@leeoniya/ufuzzy": "^1.0.14",
-    "@yaireo/tagify": "^4.31.0",
+    "@yaireo/tagify": "^4.31.3",
     "js-yaml": "^4.1.0",
     "mark.js": "^8.11.1",
     "minireset.css": "^0.0.7"
   },
   "devDependencies": {
-    "cypress": "^13.13.3",
+    "cypress": "^13.14.1",
     "cypress-fail-on-console-error": "^5.1.1",
     "eslint": "^9.9.1",
     "eslint-plugin-cypress": "^3.5.0",


### PR DESCRIPTION
"@yaireo/tagify": "^4.31.0" introduced a bug where the bookmark tagging was not correctly working anymore. (no dropdown). 

The update to latest bugfix release patches the issue. 