### PR TITLE
Fix potential crash when browser returns empty history entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [unreleased]
 
+- **FIXED**: Fixed potential crash when browser returns empty history entries (which it shouldn't do).
+
 ## [v1.10.2]
 
 - **FIXED**: Bookmark tagging autocomplete was partly broken. Fixed update of dependency.

--- a/popup/js/model/searchData.js
+++ b/popup/js/model/searchData.js
@@ -83,9 +83,9 @@ export async function getSearchData() {
       const browserHistory = []
       const idMap = {}
       for (const item of historyFromApi.concat(historyC)) {
-        if (!idMap[item.id || item.url]) {
+        if (item && item.id & !idMap[item.id]) {
           browserHistory.push(item)
-          idMap[item.id || item.url] = true
+          idMap[item.id] = true
         }
       }
 


### PR DESCRIPTION
Relates #135 