### PR TITLE
Do not look through history for default results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   - Cleaned up and simplified CSS
   - Lazy load CSS necessary for bookmark tagging and options view
   - Lazy load uFuzzy library only when fuzzy search is used
-- **CHANGED**: Initial load now only looks for bookmarks matching the current URL, not starting with it
+- **CHANGED**: Initial load now only looks for bookmarks and only returns those matching the current URL, not starting with it
 
 ## [v1.10.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Lazy load CSS necessary for bookmark tagging and options view
   - Lazy load uFuzzy library only when fuzzy search is used
 - **CHANGED**: Initial load now only looks for bookmarks and only returns those matching the current URL, not starting with it
+- **FIXED**: Re-apply search when switching search mode between precise and fuzzy
 
 ## [v1.10.3]
 

--- a/popup/js/search/defaultEntries.js
+++ b/popup/js/search/defaultEntries.js
@@ -37,18 +37,15 @@ export async function addDefaultEntries() {
       }
     })
   } else {
-    // All other modes: Find bookmarks / history that matches current page URL
+    // Default: Find bookmarks that match current page URL
     let currentUrl = window.location.href
     const [tab] = await getBrowserTabs({ active: true, currentWindow: true })
     if (!tab) {
       return []
     }
-
     // Remove trailing slash or hash from URL, so the comparison works better
     currentUrl = tab.url.replace(/[/#]$/, '')
-
     results.push(...ext.model.bookmarks.filter((el) => el.originalUrl === currentUrl))
-    results.push(...ext.model.history.filter((el) => el.originalUrl === currentUrl))
   }
 
   ext.model.result = results

--- a/popup/js/view/searchView.js
+++ b/popup/js/view/searchView.js
@@ -5,6 +5,7 @@
 import { timeSince } from '../helper/utils.js'
 import { initExtension } from '../initSearch.js'
 import { getUserOptions, setUserOptions } from '../model/options.js'
+import { search } from '../search/common.js'
 
 /**
  * Render the search results in UI as result items
@@ -391,10 +392,9 @@ export async function toggleSearchApproach() {
 
   userOptions.searchStrategy = ext.opts.searchStrategy
 
-  // Update user options
   await setUserOptions(userOptions)
-  // Init extension again
   await initExtension()
+  search()
 }
 
 /**


### PR DESCRIPTION
- **CHANGED**: Initial load now only looks for bookmarks and only returns those matching the current URL, not starting with it
- **FIXED**: Re-apply search when switching search mode between precise and fuzzy