### PR TITLE
Add support for bookmark folder and tags badge navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [unreleased]
 
 - **ADDED**: The folder and tags label on a bookmark search result are now clickable and will lead to a new search, looking for all bookmarks with the same folder / tags.
+- **IMPROVED**: Folders and Tags are now rendered with a badge for each value, now also clickable for navigation
 
 ## [v1.12.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [unreleased]
 
-- **ADDED**: The folder and tags label on a bookmark search result are now clickable and will lead to a new search
+- **ADDED**: The folder and tags label on a bookmark search result are now clickable and will lead to a new search, looking for all bookmarks with the same folder / tags.
 
 ## [v1.12.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [unreleased]
 
+- **ADDED**: The folder and tags label on a bookmark search result are now clickable and will lead to a new search
+
 ## [v1.12.0]
 
 - **CHANGED**: History cache has been removed as it caused issues with local storage size on some browser and performance gains were not clear enough.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [unreleased]
 
+- **Added**: Support for direct URL navigation, contributed by [@berdon](https://github.com/berdon) via [#171](https://github.com/Fannon/search-bookmarks-history-and-tabs/pull/171)
 - **ADDED**: The folder and tags label on a bookmark search result are now clickable and will lead to a new search, looking for all bookmarks with the same folder / tags.
 - **IMPROVED**: Folders and Tags are now rendered with a badge for each value, now also clickable for navigation
 

--- a/cypress/e2e/search.cy.js
+++ b/cypress/e2e/search.cy.js
@@ -171,6 +171,19 @@ describe('Search View', () => {
     })
   })
 
+  describe('Direct URL Search', () => {
+    it('can execute a direct URL search successfully', () => {
+      cy.get('#search-input')
+        .type(`example.com`)
+        cy.get('#result-list')
+        .should('not.have.length', 0)
+      cy.get('li.direct')
+        .should('have.length', 1)
+        .should('have.attr', 'x-open-url', 'https://example.com')
+      cy.checkNoErrors()
+    })
+  })
+
   describe('Bookmark search', () => {
     it('Empty search returns recent bookmarks', () => {
       cy.get('#search-input')

--- a/popup/css/style.css
+++ b/popup/css/style.css
@@ -152,13 +152,13 @@ code {
   color: #a2bbd6;
 }
 .folder {
-  background: #559292;
+  background: #3c8d8d;
 }
 .folder .divider:before {
   content: ' \276F \0020';
 }
 .folder mark {
-  color: #c5e9e9;
+  color: #8fefef;
 }
 .folder small {
   color: #a3d0d0;

--- a/popup/css/style.css
+++ b/popup/css/style.css
@@ -266,7 +266,8 @@ li.error {
 .edit-button:hover,
 .close-button:hover {
   background: rgba(255, 255, 255, 0.12);
-  border-radius: 3px;
+  border-radius: 4px;
+  filter: brightness(135%);
 }
 .title {
   font-size: 18px;

--- a/popup/css/style.css
+++ b/popup/css/style.css
@@ -158,10 +158,14 @@ code {
   content: ' \276F \0020';
 }
 .folder mark {
-  color: #85dbdb;
+  color: #c5e9e9;
 }
 .folder small {
   color: #a3d0d0;
+}
+.folder:hover,
+.tags:hover {
+  filter: brightness(125%);
 }
 .window {
   background: #8061ca;

--- a/popup/js/initSearch.js
+++ b/popup/js/initSearch.js
@@ -86,7 +86,7 @@ export async function initExtension() {
   document.addEventListener('keydown', navigationKeyListener)
   window.addEventListener('hashchange', hashRouter, false)
   ext.dom.searchApproachToggle.addEventListener('mouseup', toggleSearchApproach)
-  ext.dom.searchInput.addEventListener('keyup', search)
+  ext.dom.searchInput.addEventListener('input', search)
 
   // Display default entries
   await addDefaultEntries()

--- a/popup/js/model/options.js
+++ b/popup/js/model/options.js
@@ -65,7 +65,7 @@ export const defaultOptions = {
   /**
    * Color for bookmark results, expressed as CSS color
    */
-  bookmarkColor: '#54afaf',
+  bookmarkColor: '#3c8d8d',
   /**
    * Color for tab results, expressed as CSS color
    */

--- a/popup/js/model/options.js
+++ b/popup/js/model/options.js
@@ -286,7 +286,7 @@ export const defaultOptions = {
    * Base score for custom search engine choices
    * This is set very high to ensure that it's the topmost entry
    */
-  scoreCustomSearchEngineBaseScore: 500,
+  scoreCustomSearchEngineBaseScore: 400,
   /**
    * Base score for a direct URL being typed in
    */

--- a/popup/js/search/common.js
+++ b/popup/js/search/common.js
@@ -15,7 +15,6 @@ import { searchTaxonomy } from './taxonomySearch.js'
  * It will decide which approaches and indexes to use.
  */
 export async function search(event) {
-  console.log(event)
   try {
     if (event) {
       // Don't execute search on navigation keys

--- a/popup/js/search/common.js
+++ b/popup/js/search/common.js
@@ -38,10 +38,9 @@ export async function search(event) {
     searchTerm = searchTerm.replace(/ +(?= )/g, '') // Remove duplicate spaces
 
     if (!searchTerm.trim()) {
-      // Early return if no search term
       ext.model.result = []
       renderSearchResults(ext.model.result)
-      return
+      return // Early return if no search term
     }
 
     if (ext.opts.debug) {
@@ -160,8 +159,6 @@ export async function search(event) {
 
 /**
  * Search with a with a specific approach and combine the results.
- *
- * @searchApproach 'precise' | 'fuzzy'
  */
 export async function searchWithAlgorithm(searchApproach, searchTerm, searchMode = 'all') {
   let results = []

--- a/popup/js/search/common.js
+++ b/popup/js/search/common.js
@@ -15,6 +15,7 @@ import { searchTaxonomy } from './taxonomySearch.js'
  * It will decide which approaches and indexes to use.
  */
 export async function search(event) {
+  console.log(event)
   try {
     if (event) {
       // Don't execute search on navigation keys
@@ -38,7 +39,10 @@ export async function search(event) {
     searchTerm = searchTerm.replace(/ +(?= )/g, '') // Remove duplicate spaces
 
     if (!searchTerm.trim()) {
-      return // Early return if no search term
+      // Early return if no search term
+      ext.model.result = []
+      renderSearchResults(ext.model.result)
+      return
     }
 
     if (ext.opts.debug) {

--- a/popup/js/search/common.js
+++ b/popup/js/search/common.js
@@ -128,8 +128,8 @@ export async function search(event) {
         const url = protocolRegex.test(searchTerm) ? searchTerm : `https://${searchTerm.replace(/^\/+/, '')}`
         ext.model.result.push({
           type: 'direct',
-          title: 'Direct',
-          titleHighlighted: 'Direct',
+          title: `Direct: "${cleanUpUrl(url)}"`,
+          titleHighlighted: `Direct: "<mark>${cleanUpUrl(url)}</mark>"`,
           url: cleanUpUrl(url),
           urlHighlighted: cleanUpUrl(url),
           originalUrl: url,

--- a/popup/js/search/fuzzySearch.js
+++ b/popup/js/search/fuzzySearch.js
@@ -116,12 +116,6 @@ function fuzzySearchWithScoring(searchTerm, searchMode) {
         if (highlightArray[1] && highlightArray[1].includes('<mark>')) {
           result.urlHighlighted = highlightArray[1]
         }
-        if (highlightArray[2] && highlightArray[2].includes('<mark>')) {
-          result.tagsHighlighted = highlightArray[2]
-        }
-        if (highlightArray[3] && highlightArray[3].includes('<mark>')) {
-          result.folderHighlighted = highlightArray[3]
-        }
 
         localResults.push({
           ...result,

--- a/popup/js/view/searchView.js
+++ b/popup/js/view/searchView.js
@@ -37,6 +37,7 @@ export function renderSearchResults(result) {
     if (resultEntry.type === 'bookmark') {
       const editImg = document.createElement('img')
       editImg.classList.add('edit-button')
+      editImg.setAttribute('x-link', '#edit-bookmark/' + resultEntry.originalId)
       editImg.title = 'Edit Bookmark'
       editImg.src = '../images/edit.svg'
       resultListItem.appendChild(editImg)
@@ -71,36 +72,27 @@ export function renderSearchResults(result) {
     }
     titleDiv.appendChild(titleText)
 
-    if (ext.opts.displayTags && resultEntry.tags) {
-      const tags = document.createElement('span')
-      tags.title = 'Bookmark Tags'
-      tags.classList.add('badge', 'tags')
-      if (
-        ext.opts.displaySearchMatchHighlight &&
-        resultEntry.tagsHighlighted &&
-        resultEntry.tagsHighlighted.includes('<mark>')
-      ) {
-        tags.innerHTML = resultEntry.tagsHighlighted
-      } else {
-        tags.innerText = resultEntry.tags
+    if (ext.opts.displayTags && resultEntry.tagsArray) {
+      for (const tag of resultEntry.tagsArray) {
+        const tagEl = document.createElement('span')
+        tagEl.title = 'Bookmark Tags'
+        tagEl.classList.add('badge', 'tags')
+        tagEl.setAttribute('x-link', `#search/#${tag}`)
+        if (ext.opts.displaySearchMatchHighlight) {
+          tagEl.innerText = '#' + tag
+        }
+        titleDiv.appendChild(tagEl)
       }
-      titleDiv.appendChild(tags)
     }
     if (ext.opts.displayFolderName && resultEntry.folder) {
       const folder = document.createElement('span')
       folder.title = 'Bookmark Folder'
       folder.classList.add('badge', 'folder')
-
+      folder.setAttribute('x-link', `#search/${resultEntry.folder}`)
       if (ext.opts.bookmarkColor) {
         folder.style = `background-color: ${ext.opts.bookmarkColor}`
       }
-      if (
-        ext.opts.displaySearchMatchHighlight &&
-        resultEntry.folderHighlighted &&
-        resultEntry.folderHighlighted.includes('<mark>')
-      ) {
-        folder.innerHTML = resultEntry.folderHighlighted
-      } else {
+      if (ext.opts.displaySearchMatchHighlight) {
         folder.innerText = resultEntry.folder
       }
       titleDiv.appendChild(folder)
@@ -267,16 +259,8 @@ export function openResultItem(event) {
 
     // If the event is a click event on the edit button or other clickable elements:
     // Do not go to the URL itself, but to the internal linked url
-    if (target && target.className.includes('folder')) {
-      const r = ext.model.result.find((el) => el.originalId === originalId)
-      window.location = '#search/' + r.folder
-      return
-    } else if (target && target.className.includes('tags')) {
-      const r = ext.model.result.find((el) => el.originalId === originalId)
-      window.location = '#search/' + r.tags
-      return
-    } else if (target && target.className.includes('edit-button')) {
-      window.location = '#edit-bookmark/' + originalId
+    if (target && target.getAttribute('x-link')) {
+      window.location = target.getAttribute('x-link')
       return
     } else if (target && target.className.includes('close-button')) {
       const targetId = parseInt(originalId)

--- a/popup/js/view/searchView.js
+++ b/popup/js/view/searchView.js
@@ -262,7 +262,7 @@ export function openResultItem(event) {
     event.stopPropagation()
     let target = event.target ? event.target : event.srcElement
     if (target.nodeName === 'MARK') {
-      target = target.parent
+      target = target.parentNode
     }
 
     // If the event is a click event on the edit button or other clickable elements:
@@ -304,10 +304,6 @@ export function openResultItem(event) {
       return
     }
   }
-
-  event.stopPropagation()
-  console.warn('STOP HERE')
-  return
 
   // Right click mouse -> copy URL of result to clipboard
   if (event.button === 2) {

--- a/popup/js/view/searchView.js
+++ b/popup/js/view/searchView.js
@@ -260,33 +260,22 @@ export function openResultItem(event) {
       target = target.parentNode
     }
 
-    // If the event is a click event on the edit button or other clickable elements:
-    // Do not go to the URL itself, but to the internal linked url
+    // If the event is a click event on an navigation element (x-link), follow that link
     if (target && target.getAttribute('x-link')) {
       window.location = target.getAttribute('x-link')
       return
     } else if (target && target.className.includes('close-button')) {
       const targetId = parseInt(originalId)
-
-      // Close Browser Tab
-      ext.browserApi.tabs.remove(targetId)
-
-      // Remove search list entry
+      ext.browserApi.tabs.remove(targetId) // Close Browser Tab
       document.querySelector(`#result-list > li[x-original-id="${originalId}"]`).remove(targetId)
-
-      // Remove closed tab from index model
       ext.model.tabs.splice(
         ext.model.tabs.findIndex((el) => el.originalId === targetId),
         1,
       )
-
-      // Remove closed tab from search result
       ext.model.result.splice(
         ext.model.result.findIndex((el) => el.originalId === targetId),
         1,
       )
-
-      // Render search results again to avoid display bugs
       renderSearchResults()
       return
     }
@@ -299,8 +288,7 @@ export function openResultItem(event) {
     return
   }
 
-  // If we press SHIFT or ALT while selecting an entry:
-  // -> Open it in current tab
+  // If we press SHIFT or ALT while selecting an entry: Open it in current tab
   if (event.shiftKey || event.altKey) {
     if (ext.browserApi.tabs) {
       ext.browserApi.tabs
@@ -325,8 +313,7 @@ export function openResultItem(event) {
     return
   }
 
-  // If we press CTRL while selecting an entry
-  // -> Open it in new tab in the background (don't close popup)
+  // If we press CTRL while selecting an entry: Open it in new tab in the background (don't close popup)
   if (event.ctrlKey) {
     if (ext.browserApi.tabs) {
       ext.browserApi.tabs.create({
@@ -339,23 +326,19 @@ export function openResultItem(event) {
     return
   }
 
-  // If we use no modifier when selecting an entry:
-  // -> Navigate to selected tab or link. Prefer browser tab API if available.
+  // If we use no modifier when selecting an entry: Navigate to selected tab or link. Prefer browser tab API if available.
   const foundTab = ext.model.tabs.find((el) => {
     return el.originalUrl === url
   })
-
   if (foundTab && ext.browserApi.tabs.highlight) {
     // Set the found tab active
     ext.browserApi.tabs.update(foundTab.originalId, {
       active: true,
     })
-
     // Switch browser window focus if necessary
     ext.browserApi.windows.update(foundTab.windowId, {
       focused: true,
     })
-
     window.close()
   } else if (ext.browserApi.tabs) {
     ext.browserApi.tabs.create({

--- a/popup/js/view/searchView.js
+++ b/popup/js/view/searchView.js
@@ -260,11 +260,22 @@ export function openResultItem(event) {
 
   if (event) {
     event.stopPropagation()
-    const target = event.target ? event.target : event.srcElement
+    let target = event.target ? event.target : event.srcElement
+    if (target.nodeName === 'MARK') {
+      target = target.parent
+    }
 
-    // If the event is a click event on the edit image:
-    // Do not go to the URL itself, but to the internal edit bookmark url
-    if (target && target.className.includes('edit-button')) {
+    // If the event is a click event on the edit button or other clickable elements:
+    // Do not go to the URL itself, but to the internal linked url
+    if (target && target.className.includes('folder')) {
+      const r = ext.model.result.find((el) => el.originalId === originalId)
+      window.location = '#search/' + r.folder
+      return
+    } else if (target && target.className.includes('tags')) {
+      const r = ext.model.result.find((el) => el.originalId === originalId)
+      window.location = '#search/' + r.tags
+      return
+    } else if (target && target.className.includes('edit-button')) {
       window.location = '#edit-bookmark/' + originalId
       return
     } else if (target && target.className.includes('close-button')) {
@@ -293,6 +304,10 @@ export function openResultItem(event) {
       return
     }
   }
+
+  event.stopPropagation()
+  console.warn('STOP HERE')
+  return
 
   // Right click mouse -> copy URL of result to clipboard
   if (event.button === 2) {

--- a/popup/js/view/searchView.js
+++ b/popup/js/view/searchView.js
@@ -96,7 +96,7 @@ export function renderSearchResults(result) {
           el.style = `background-color: ${ext.opts.bookmarkColor}`
         }
         if (ext.opts.displaySearchMatchHighlight) {
-          el.innerText = f
+          el.innerText = '~' + f
         }
         titleDiv.appendChild(el)
       }

--- a/popup/js/view/searchView.js
+++ b/popup/js/view/searchView.js
@@ -74,28 +74,32 @@ export function renderSearchResults(result) {
 
     if (ext.opts.displayTags && resultEntry.tagsArray) {
       for (const tag of resultEntry.tagsArray) {
-        const tagEl = document.createElement('span')
-        tagEl.title = 'Bookmark Tags'
-        tagEl.classList.add('badge', 'tags')
-        tagEl.setAttribute('x-link', `#search/#${tag}`)
+        const el = document.createElement('span')
+        el.title = 'Bookmark Tags'
+        el.classList.add('badge', 'tags')
+        el.setAttribute('x-link', `#search/#${tag}`)
         if (ext.opts.displaySearchMatchHighlight) {
-          tagEl.innerText = '#' + tag
+          el.innerText = '#' + tag
         }
-        titleDiv.appendChild(tagEl)
+        titleDiv.appendChild(el)
       }
     }
-    if (ext.opts.displayFolderName && resultEntry.folder) {
-      const folder = document.createElement('span')
-      folder.title = 'Bookmark Folder'
-      folder.classList.add('badge', 'folder')
-      folder.setAttribute('x-link', `#search/${resultEntry.folder}`)
-      if (ext.opts.bookmarkColor) {
-        folder.style = `background-color: ${ext.opts.bookmarkColor}`
+    if (ext.opts.displayFolderName && resultEntry.folderArray) {
+      const trail = []
+      for (const f of resultEntry.folderArray) {
+        trail.push(f)
+        const el = document.createElement('span')
+        el.title = 'Bookmark Folder'
+        el.classList.add('badge', 'folder')
+        el.setAttribute('x-link', `#search/~${trail.join(' ~')}`)
+        if (ext.opts.bookmarkColor) {
+          el.style = `background-color: ${ext.opts.bookmarkColor}`
+        }
+        if (ext.opts.displaySearchMatchHighlight) {
+          el.innerText = f
+        }
+        titleDiv.appendChild(el)
       }
-      if (ext.opts.displaySearchMatchHighlight) {
-        folder.innerText = resultEntry.folder
-      }
-      titleDiv.appendChild(folder)
     }
     if (ext.opts.displayLastVisit && resultEntry.lastVisitSecondsAgo) {
       const lastVisit = timeSince(new Date(Date.now() - resultEntry.lastVisitSecondsAgo * 1000))
@@ -141,7 +145,6 @@ export function renderSearchResults(result) {
       urlDiv.innerText = resultEntry.url
     }
 
-    // Append everything together :)
     resultListItem.appendChild(titleDiv)
     resultListItem.appendChild(urlDiv)
     resultListItem.addEventListener('mouseenter', hoverResultItem)


### PR DESCRIPTION
- **ADDED**: The folder and tags label on a bookmark search result are now clickable and will lead to a new search, looking for all bookmarks with the same folder / tags.
- **IMPROVED**: Folders and Tags are now rendered with a badge for each value, now also clickable for navigation

![NavigateBookmarkFolders](https://github.com/user-attachments/assets/eb9c1077-03f7-40ef-90bf-cc3ca13c9e7e)

