### PR TITLE
Optimize CI workflow runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,8 @@ jobs:
           cache: 'npm'
       - name: Install Dependencies
         run: npm ci
+      - name: Ensure Cypress binary
+        run: npx cypress install
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
@@ -172,6 +174,8 @@ jobs:
           cache: 'npm'
       - name: Install Dependencies
         run: npm ci
+      - name: Ensure Cypress binary
+        run: npx cypress install
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,6 @@ jobs:
         with:
           browser: edge
           # build: npm run build
-          install: false
           start: npm start
           wait-on: http://localhost:8080
       - name: Upload screenshots

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: Build & Lint
+    name: Build, Lint & Unit Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -46,29 +46,14 @@ jobs:
         run: npm run build
       - name: Lint
         run: npm run lint
+      - name: Unit Tests
+        run: npm run test:unit
       - name: Save build folder
         uses: actions/upload-artifact@v4
         with:
           name: popup
           path: popup
           if-no-files-found: error
-
-  unit-test:
-    name: Unit Tests
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.x
-          cache: 'npm'
-      - name: Install Dependencies
-        run: npm set cache ~/.npm && npm ci
-      - name: Run Unit Tests
-        run: npm run test:unit
 
   cypress-run-chrome:
     runs-on: ubuntu-24.04
@@ -81,9 +66,17 @@ jobs:
         with:
           name: popup
           path: popup
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'npm'
+      - name: Install Dependencies
+        run: npm ci
       - uses: cypress-io/github-action@v6
         with:
           browser: chrome
+          install: false
           start: npm start
           wait-on: http://localhost:8080
       - name: Upload screenshots
@@ -105,10 +98,18 @@ jobs:
         with:
           name: popup
           path: popup
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'npm'
+      - name: Install Dependencies
+        run: npm ci
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
           browser: firefox
+          install: false
           start: npm start
           wait-on: http://localhost:8080
       - name: Upload screenshots
@@ -130,11 +131,19 @@ jobs:
         with:
           name: popup
           path: popup
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'npm'
+      - name: Install Dependencies
+        run: npm ci
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
           browser: edge
           # build: npm run build
+          install: false
           start: npm start
           wait-on: http://localhost:8080
       - name: Upload screenshots
@@ -156,11 +165,19 @@ jobs:
         with:
           name: popup
           path: popup
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'npm'
+      - name: Install Dependencies
+        run: npm ci
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
           browser: edge
           # build: npm run build
+          install: false
           start: npm start
           wait-on: http://localhost:8080
       - name: Upload screenshots

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: npm run build
       - name: Lint
         run: npm run lint
-      - name: Unit Tests
+      - name: Unit Test
         run: npm run test:unit
       - name: Save build folder
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: Build, Lint & Unit Tests
+    name: Build, Lint & Unit Test
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
- run unit tests within the build job to avoid a second dependency installation
- prepare each Cypress job with cached Node.js dependencies and skip the action’s internal install step

## Testing
- not run (CI workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68e229a1c85883318a6f704c17ca2659