### PR TITLE
Fix ZIP file creation

### DIFF
--- a/bin/createDist.js
+++ b/bin/createDist.js
@@ -51,7 +51,7 @@ export async function createDist(clean = true) {
     archive.on('error', reject)
 
     archive.pipe(output)
-    archive.directory('dist/chrome/', '.')
+    archive.directory('dist/chrome/', false)
     archive.finalize()
   })
 }


### PR DESCRIPTION
Zip file created started with "." folder, but for upload to stores the `manifest.json` file needs to be at root.