### PR TITLE
Remove unnecessary hashchange event listener

### DIFF
--- a/popup/js/initSearch.js
+++ b/popup/js/initSearch.js
@@ -53,7 +53,6 @@ export async function initExtension() {
 
   // Register Events
   document.addEventListener('keydown', navigationKeyListener)
-  window.addEventListener('hashchange', hashRouter, false)
   ext.dom.searchApproachToggle.addEventListener('mouseup', toggleSearchApproach)
 
   // Add debounced search to prevent excessive calls on rapid typing


### PR DESCRIPTION
## Description

This PR removes an unnecessary `window.addEventListener('hashchange', hashRouter, false)` from the `initSearch.js` file.

## Analysis

The hashchange listener was redundant because:

1. **The `hashRouter()` function is already called during initialization** - it handles the initial hash state when the page loads
2. **The main search functionality is driven by the input event listener** - search is triggered by user input, not hash changes  
3. **The hash is primarily used for**:
   - Initial page load with a search term (e.g., `yoursite.com#search/your%20query`)
   - Bookmarking/sharing search results
   - Navigation state management

## What the hashRouter actually does:

The `hashRouter()` function:
- Reads the current `window.location.hash`
- If it starts with `#search/`, extracts the search term and populates the search input
- Calls `search()` or shows default entries
- This is essentially a **one-way operation** - it reads the hash to initialize state

## Benefits:

- **Cleaner code**: Removes unnecessary event listener
- **Better performance**: One less event listener to manage
- **Improved maintainability**: Less code to maintain and debug

## Testing:

The existing test suite should continue to pass as this change only removes redundant code without affecting functionality.