### PR TITLE
Avoid mutating fuzzy highlight results

### DIFF
--- a/popup/js/search/__tests__/fuzzySearch.test.js
+++ b/popup/js/search/__tests__/fuzzySearch.test.js
@@ -9,6 +9,7 @@ const cjkTerm = '\u6f22\u5b57'
 let uFuzzyInstances = []
 let uFuzzyCallHistory = []
 let originalUFuzzy = null
+let lastSearchTerm = ''
 
 // Enhanced uFuzzy wrapper that tracks calls while using real implementation
 class TrackedUFuzzy {
@@ -27,6 +28,7 @@ class TrackedUFuzzy {
   }
 
   filter(haystack, term) {
+    lastSearchTerm = term
     uFuzzyCallHistory.push({
       method: 'filter',
       instanceId: this.instanceId,
@@ -48,6 +50,7 @@ class TrackedUFuzzy {
   }
 
   info(indices, haystack, term) {
+    lastSearchTerm = term
     uFuzzyCallHistory.push({
       method: 'info',
       instanceId: this.instanceId,
@@ -78,18 +81,18 @@ class TrackedUFuzzy {
     }
 
     // Fallback highlighting implementation
-    const parts = searchString.split(delimiter)
-    const highlightedParts = parts.map((part) => {
-      // Simple highlighting for fallback
-      return part // Return as-is for now, real uFuzzy will handle this
-    })
+    if (lastSearchTerm) {
+      const termRegex = new RegExp(lastSearchTerm, 'gi')
+      return searchString.replace(termRegex, (match) => `<mark>${match}</mark>`)
+    }
 
-    return highlightedParts.join(delimiter)
+    return searchString
   }
 
   static reset() {
     uFuzzyInstances = []
     uFuzzyCallHistory = []
+    lastSearchTerm = ''
   }
 
   static getInstances() {
@@ -455,5 +458,31 @@ describe('fuzzySearch', () => {
     expect(bookmarkResults[0].id).toBe('bookmark-1')
     expect(tabResults).toHaveLength(1)
     expect(tabResults[0].id).toBe('tab-1')
+  })
+
+  it('does not mutate cached entries when adding highlight strings', async () => {
+    ext.model.bookmarks = [
+      {
+        id: 'bookmark-highlight',
+        title: 'Highlight persistence test',
+        url: 'https://example.com/highlight',
+        searchString: `highlight persistence test${delimiter}https://example.com/highlight`,
+      },
+    ]
+
+    const firstResults = await fuzzySearch('bookmarks', 'highlight')
+
+    expect(firstResults).toHaveLength(1)
+    const firstResult = firstResults[0]
+    expect(firstResult).not.toBe(ext.model.bookmarks[0])
+    expect(firstResult.titleHighlighted || '').toContain('<mark>')
+    expect(ext.model.bookmarks[0].titleHighlighted).toBeUndefined()
+    expect(ext.model.bookmarks[0].urlHighlighted).toBeUndefined()
+
+    const secondResults = await fuzzySearch('bookmarks', 'highlight')
+
+    expect(secondResults[0]).not.toBe(ext.model.bookmarks[0])
+    expect(ext.model.bookmarks[0].titleHighlighted).toBeUndefined()
+    expect(ext.model.bookmarks[0].urlHighlighted).toBeUndefined()
   })
 })

--- a/popup/js/search/fuzzySearch.js
+++ b/popup/js/search/fuzzySearch.js
@@ -119,15 +119,22 @@ function fuzzySearchWithScoring(searchTerm, searchMode) {
         const highlight = uFuzzy.highlight(result.searchString, info.ranges[i])
         // Split highlighted string back into its original multiple properties
         const highlightArray = highlight.split('¦')
+        const highlightedResult = {
+          ...result,
+        }
         if (highlightArray[0] && highlightArray[0].includes('<mark>')) {
-          result.titleHighlighted = highlightArray[0]
+          highlightedResult.titleHighlighted = highlightArray[0]
+        } else {
+          delete highlightedResult.titleHighlighted
         }
         if (highlightArray[1] && highlightArray[1].includes('<mark>')) {
-          result.urlHighlighted = highlightArray[1]
+          highlightedResult.urlHighlighted = highlightArray[1]
+        } else {
+          delete highlightedResult.urlHighlighted
         }
 
         localResults.push({
-          ...result,
+          ...highlightedResult,
           // 0 intra chars are perfect score, 5 and more are 0 score.
           searchScore: Math.max(0, 1 * (1 - info.intraIns[i] / 5)),
           searchApproach: 'fuzzy',


### PR DESCRIPTION
## Summary
- clone fuzzy search results before applying highlight markup so cached entries stay pristine
- ensure the fallback uFuzzy highlight helper emits markup for tests
- add regression coverage that verifies highlight markup never sticks to ext.model data

## Testing
- npm run test:unit popup/js/search/__tests__/fuzzySearch.test.js