### PR TITLE
Refine search scoring changelog details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [unreleased]
 
 - **IMPROVED**: Improved scoring logic through a few minor bugfixes, better defaults and better documentation.
-  - See **[popup/js/search/scoring.js](popup/js/search/scoring.js)** for comprehensive documentation
+  - Detailed user-visible scoring adjustments are documented in the [search result scoring changelog](docs/search-scoring-changelog.md).
+- **DOCS**: Added a dedicated [search result scoring changelog](docs/search-scoring-changelog.md) that tracks ranking-affecting changes across releases.
 - **IMPROVED**: Init load Performance: further reduced initial load bundle size
 - **FIXED**: When editing a bookmark and saving, the search state was sometimes not properly updated. Now the search is completely reset, but remembers the search term
 

--- a/docs/search-scoring-changelog.md
+++ b/docs/search-scoring-changelog.md
@@ -1,0 +1,13 @@
+# Search Result Scoring Changelog
+
+This log tracks user-visible changes to how popup search results are ranked across releases.
+
+## v1.16.0
+
+- **Higher bonuses for perfect matches.** Exact matches on titles, tags, and folders now receive +20, +15, and +10 points respectively (previously +15, +10, +5), so precise results appear ahead of partial matches by default.
+- **Better handling of multi-term queries.** Search terms are evaluated individually in a case-insensitive way, ensuring multi-word queries and mixed-case text reliably trigger the configured substring bonuses.
+
+## v1.15.0
+
+- **Recency bonus applies to just-opened items.** Results you opened moments ago now receive the maximum recency bonus instead of being skipped.
+- **Option names for base weights shortened.** Custom configuration keys for base bookmark, history, and tab weights no longer include the trailing "Score" word, so existing overrides must adopt the shorter names to keep working.


### PR DESCRIPTION
## Summary
- document release-to-release scoring changes in a dedicated search scoring changelog with user-focused language
- link to the detailed scoring changelog from the main CHANGELOG entry about scoring improvements

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f8676663ec8331b3fbd8c7bc143b82