### PR TITLE
Flush pending search before opening result on Enter

### DIFF
--- a/popup/js/helper/extensionContext.js
+++ b/popup/js/helper/extensionContext.js
@@ -38,6 +38,13 @@ export function createExtensionContext() {
       currentItem: 0,
       /** Current search results array */
       result: [],
+      /** Tracks pending debounced search state */
+      searchDebounce: {
+        timeoutId: null,
+        isPending: false,
+      },
+      /** Flush handler assigned during initialization */
+      flushPendingSearch: null,
     },
     /** Search indexes (e.g., taxonomy for tags and folders) */
     index: {

--- a/popup/js/view/searchNavigation.js
+++ b/popup/js/view/searchNavigation.js
@@ -14,7 +14,7 @@ import { openResultItem } from './searchEvents.js'
  * Handle keyboard navigation for search results
  * Supports arrow keys and vim-style keybindings (Ctrl+P/Ctrl+N, Ctrl+K/Ctrl+J)
  */
-export function navigationKeyListener(event) {
+export async function navigationKeyListener(event) {
   // Define navigation directions with multiple keybinding options
   const up = event.key === 'ArrowUp' || (event.ctrlKey && event.key === 'p') || (event.ctrlKey && event.key === 'k')
   const down = event.key === 'ArrowDown' || (event.ctrlKey && event.key === 'n') || (event.ctrlKey && event.key === 'j')
@@ -30,9 +30,17 @@ export function navigationKeyListener(event) {
     // Navigate to next result
     event.preventDefault()
     selectListItem(ext.model.currentItem + 1, true)
-  } else if (event.key === 'Enter' && ext.model.result.length > 0) {
+  } else if (event.key === 'Enter') {
     // Activate selected result when Enter is pressed
-    if (window.location.hash.startsWith('#search/') || !window.location.hash) {
+    if (ext.model.result.length > 0 && (window.location.hash.startsWith('#search/') || !window.location.hash)) {
+      if (typeof ext.model.flushPendingSearch === 'function') {
+        await ext.model.flushPendingSearch()
+      }
+
+      if (ext.model.result.length === 0 || !document.getElementById('selected-result')) {
+        return
+      }
+
       openResultItem(event)
     }
   } else if (event.key === 'Escape') {


### PR DESCRIPTION
## Summary
- track debounced search state on the shared extension context and expose a flush helper
- await any pending search work before handling Enter navigation to avoid opening stale selections
- expand the search navigation tests to cover the new flush behavior and async handler

## Testing
- npm run lint
- npm run test:unit popup/js/view/__tests__/searchNavigation.test.js
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68fa2664b1408331802ab64af0576eae