### PR TITLE
Fix Whitespace Matching Issue in Search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -663,7 +662,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -687,7 +685,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2611,7 +2608,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3132,7 +3128,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -3816,7 +3811,6 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5370,7 +5364,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -5586,6 +5579,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -5779,6 +5773,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6289,7 +6284,8 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "peer": true
     },
     "node_modules/readable-stream": {
       "version": "4.7.0",
@@ -6483,6 +6479,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -7575,7 +7572,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -7929,15 +7925,13 @@
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
       "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
       "dev": true,
-      "peer": true,
       "requires": {}
     },
     "@csstools/css-tokenizer": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
       "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@emnapi/core": {
       "version": "1.5.0",
@@ -9145,8 +9139,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -9474,7 +9467,6 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.3.tgz",
       "integrity": "sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==",
       "dev": true,
-      "peer": true,
       "requires": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -9928,7 +9920,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10999,7 +10990,6 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -11166,6 +11156,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -11305,7 +11296,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "peer": true
     },
     "on-headers": {
       "version": "1.1.0",
@@ -11652,7 +11644,8 @@
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "peer": true
     },
     "readable-stream": {
       "version": "4.7.0",
@@ -11787,6 +11780,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }

--- a/popup/js/search/__tests__/taxonomySearch.test.js
+++ b/popup/js/search/__tests__/taxonomySearch.test.js
@@ -108,4 +108,70 @@ describe('taxonomy search', () => {
     expect(second.Work).toEqual(['2'])
     expect(second).not.toBe(first)
   })
+
+  test('searchTaxonomy handles trailing whitespace in tag terms', () => {
+    const { searchTaxonomy } = taxonomyModule
+    const data = [
+      {
+        originalId: '1',
+        tags: '#react #node',
+        type: 'bookmark',
+      },
+      {
+        originalId: '2',
+        tags: '#react',
+        type: 'bookmark',
+      },
+    ]
+
+    // Test with trailing whitespace after tag
+    const resultWithTrailingSpace = searchTaxonomy('react ', 'tags', data)
+    expect(resultWithTrailingSpace).toHaveLength(2)
+    expect(resultWithTrailingSpace[0].originalId).toBe('1')
+    expect(resultWithTrailingSpace[1].originalId).toBe('2')
+
+    // Test with multiple tags where last has trailing whitespace
+    const resultMultipleTags = searchTaxonomy('react #node ', 'tags', data)
+    expect(resultMultipleTags).toHaveLength(1)
+    expect(resultMultipleTags[0].originalId).toBe('1')
+  })
+
+  test('searchTaxonomy handles trailing whitespace in folder terms', () => {
+    const { searchTaxonomy } = taxonomyModule
+    const data = [
+      {
+        originalId: '1',
+        folder: '~Work ~Projects',
+      },
+      {
+        originalId: '2',
+        folder: '~Work',
+      },
+    ]
+
+    // Test with trailing whitespace after folder
+    const resultWithTrailingSpace = searchTaxonomy('work ', 'folder', data)
+    expect(resultWithTrailingSpace).toHaveLength(2)
+
+    // Test with multiple folders where last has trailing whitespace
+    const resultMultipleFolders = searchTaxonomy('work ~projects ', 'folder', data)
+    expect(resultMultipleFolders).toHaveLength(1)
+    expect(resultMultipleFolders[0].originalId).toBe('1')
+  })
+
+  test('searchTaxonomy ignores empty terms from excessive whitespace', () => {
+    const { searchTaxonomy } = taxonomyModule
+    const data = [
+      {
+        originalId: '1',
+        tags: '#test',
+        type: 'bookmark',
+      },
+    ]
+
+    // Test with multiple spaces creating empty terms
+    const result = searchTaxonomy('test  ', 'tags', data)
+    expect(result).toHaveLength(1)
+    expect(result[0].originalId).toBe('1')
+  })
 })

--- a/popup/js/search/taxonomySearch.js
+++ b/popup/js/search/taxonomySearch.js
@@ -33,7 +33,8 @@ export function searchTaxonomy(searchTerm, taxonomyType, data) {
       const searchString = `${entry[taxonomyType] || ''}`.toLowerCase()
       let searchTermMatches = 0
       for (const term of searchTermArray) {
-        if (searchString.includes(taxonomyMarker + term)) {
+        const trimmedTerm = term.trim()
+        if (trimmedTerm && searchString.includes(taxonomyMarker + trimmedTerm)) {
           searchTermMatches++
         }
       }


### PR DESCRIPTION
Tag and folder searches were failing when query terms had trailing whitespace (e.g., "#tag " or "~folder "). The searchTaxonomy function now trims each term before comparison, making the search feel more responsive while users type successive tags/folders.

Changes:
- Trim whitespace from each term before substring matching
- Skip empty terms that result from excessive whitespace
- Add comprehensive tests for whitespace handling in both tag and folder searches

Fixes taxonomy search flakiness during interactive typing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)