### PR TITLE
Fix tab deletion bug when findIndex returns -1

### DIFF
--- a/popup/js/view/__tests__/searchEvents.test.js
+++ b/popup/js/view/__tests__/searchEvents.test.js
@@ -2,7 +2,7 @@
  * ✅ Covered behaviors: result opening flows (close, copy, modifiers, tab switching),
  *   and search approach toggling.
  * ⚠️ Known gaps: does not verify browser navigation side effects beyond mocked APIs.
- * 🐞 Added BUG tests: none.
+ * 🐞 Added BUG tests: tab deletion with findIndex returning -1.
  */
 
 import { jest } from '@jest/globals'
@@ -192,6 +192,72 @@ describe('searchEvents openResultItem', () => {
     expect(ext.model.tabs).toHaveLength(0)
     expect(ext.model.result).toHaveLength(1)
     expect(elements.resultList.children).toHaveLength(1)
+  })
+
+  it('does not delete wrong tab when originalId is not found in model (BUG: findIndex returns -1)', async () => {
+    // Set up multiple tabs and results to verify wrong deletion doesn't occur
+    const multipleResults = [
+      {
+        type: 'tab',
+        originalId: 100,
+        originalUrl: 'https://tab1.test',
+        url: 'tab1.test',
+        title: 'Tab 1',
+        score: 10,
+      },
+      {
+        type: 'tab',
+        originalId: 200,
+        originalUrl: 'https://tab2.test',
+        url: 'tab2.test',
+        title: 'Tab 2',
+        score: 9,
+      },
+      {
+        type: 'tab',
+        originalId: 300,
+        originalUrl: 'https://tab3.test',
+        url: 'tab3.test',
+        title: 'Tab 3',
+        score: 8,
+      },
+    ]
+
+    const { module, viewModule } = await setupSearchEvents({ results: multipleResults })
+    await viewModule.renderSearchResults()
+
+    // Store initial state
+    const initialTabsLength = ext.model.tabs.length
+    const initialResultLength = ext.model.result.length
+    const lastTab = { ...ext.model.tabs[ext.model.tabs.length - 1] }
+    const lastResult = { ...ext.model.result[ext.model.result.length - 1] }
+
+    // Mock the selected result to have a non-existent ID
+    const selectedResult = document.getElementById('selected-result')
+    selectedResult.setAttribute('x-original-id', '999')
+
+    // Try to close a tab with an ID that doesn't exist in the model
+    // This simulates a race condition or stale UI state
+    module.openResultItem({
+      button: 0,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      target: {
+        nodeName: 'BUTTON',
+        className: 'close-button',
+        getAttribute: () => null,
+      },
+      stopPropagation: jest.fn(),
+      preventDefault: jest.fn(),
+    })
+
+    // BEFORE FIX: splice(-1, 1) would delete the last element
+    // AFTER FIX: arrays should remain unchanged
+    expect(ext.model.tabs).toHaveLength(initialTabsLength)
+    expect(ext.model.result).toHaveLength(initialResultLength)
+    expect(ext.model.tabs[ext.model.tabs.length - 1]).toEqual(lastTab)
+    expect(ext.model.result[ext.model.result.length - 1]).toEqual(lastResult)
   })
 
   it('opens URLs in the current tab when shift is held and closes the popup afterward', async () => {

--- a/popup/js/view/searchEvents.js
+++ b/popup/js/view/searchEvents.js
@@ -50,15 +50,16 @@ export function openResultItem(event) {
       // Remove the item from the UI
       document.querySelector(`#result-list > li[x-original-id="${originalId}"]`).remove()
 
-      // Update the application state
-      ext.model.tabs.splice(
-        ext.model.tabs.findIndex((el) => el.originalId === targetId),
-        1,
-      )
-      ext.model.result.splice(
-        ext.model.result.findIndex((el) => el.originalId === targetId),
-        1,
-      )
+      // Update the application state - only remove if found (findIndex returns -1 if not found)
+      const tabIndex = ext.model.tabs.findIndex((el) => el.originalId === targetId)
+      if (tabIndex !== -1) {
+        ext.model.tabs.splice(tabIndex, 1)
+      }
+
+      const resultIndex = ext.model.result.findIndex((el) => el.originalId === targetId)
+      if (resultIndex !== -1) {
+        ext.model.result.splice(resultIndex, 1)
+      }
 
       // Re-render to update indices and selection
       renderSearchResults()


### PR DESCRIPTION
When closing a tab via the close button, if the tab's ID doesn't exist in ext.model.tabs or ext.model.result, findIndex() returns -1. JavaScript's splice(-1, 1) deletes the last element instead of doing nothing, causing the wrong tab to be deleted from the model.

This fix adds proper index checking before calling splice, preventing data corruption when tabs are not found in the model.

Includes regression test to verify the bug is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)