### PR TITLE
Cleanup / remove leftover date-added scoring logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@
 
 * **CHANGED**: More concise / simple last visited time
 
-- **FIXED**: Date-added scoring bonus now respects the new `scoreDateAddedBonusScoreMaximum`/`scoreDateAddedBonusScorePerDay` options so recently created bookmarks get their intended lift again
+- **REMOVED**: Date-added scoring bonus along with the `scoreDateAddedBonusScoreMaximum` / `scoreDateAddedBonusScorePerDay` options to keep ranking focused on usage signals.
+  - The options had already been removed, this was a code leftover
 
 ## [v1.16.0]
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,6 @@ The scoring system calculates a relevance score for each search result using a 5
 4. **Behavioral Bonuses** - Additional points based on usage patterns:
    - `scoreVisitedBonusScore` - Points per visit (up to `scoreVisitedBonusScoreMaximum`)
    - `scoreRecentBonusScoreMaximum` - Bonus for recently visited items
-   - `scoreDateAddedBonusScoreMaximum` - Bonus for recently added bookmarks
 5. **Custom Bonus** - User-defined bonus via `+<number>` notation in bookmark titles (if `scoreCustomBonusScore` is enabled)
 
 For detailed implementation and all scoring configuration options, see:

--- a/popup/js/model/options.js
+++ b/popup/js/model/options.js
@@ -381,17 +381,6 @@ export const defaultOptions = {
    */
   scoreRecentBonusScoreMaximum: 20,
   /**
-   * Adds bonus score for recently added bookmarks (linear decay).
-   * Newer bookmarks receive higher scores, older bookmarks score lower.
-   * Score = max(0, scoreDateAddedBonusScoreMaximum - (daysAgo * scoreDateAddedBonusScorePerDay))
-   */
-  scoreDateAddedBonusScoreMaximum: 10,
-  /**
-   * Score penalty per day for date-added bonus calculation.
-   * Higher values mean faster decay of the date-added bonus over time.
-   */
-  scoreDateAddedBonusScorePerDay: 2,
-  /**
    * Adds bonus points when a bookmark is also currently open as a browser tab.
    * Helps prioritize results that already exist in your session to prevent duplicate openings.
    */

--- a/popup/js/search/__tests__/scoring.test.js
+++ b/popup/js/search/__tests__/scoring.test.js
@@ -30,8 +30,6 @@ const baseOpts = {
   scoreVisitedBonusScoreMaximum: 0,
   scoreRecentBonusScoreMaximum: 0,
   historyDaysAgo: 7,
-  scoreDateAddedBonusScoreMaximum: 0,
-  scoreDateAddedBonusScorePerDay: 0,
   scoreCustomBonusScore: false,
   scoreWeakMatchPenalty: 0,
 }
@@ -371,62 +369,6 @@ describe('scoring', () => {
     })
 
     expect(score).toBeCloseTo(120)
-  })
-
-  it('adds date-added bonus with per-day decay', () => {
-    const fixedNow = 1_700_000_000_000
-    jest.spyOn(Date, 'now').mockReturnValue(fixedNow)
-
-    const score = scoreFor({
-      searchTerm: 'alpha',
-      opts: {
-        scoreDateAddedBonusScoreMaximum: 10,
-        scoreDateAddedBonusScorePerDay: 2,
-      },
-      result: {
-        dateAdded: fixedNow - 12 * 60 * 60 * 1000,
-      },
-    })
-
-    expect(score).toBeCloseTo(109)
-  })
-
-  it('drops the date-added bonus once the decay exceeds the configured maximum', () => {
-    const fixedNow = 1_700_000_000_000
-    jest.spyOn(Date, 'now').mockReturnValue(fixedNow)
-
-    const score = scoreFor({
-      searchTerm: 'alpha',
-      opts: {
-        scoreDateAddedBonusScoreMaximum: 10,
-        scoreDateAddedBonusScorePerDay: 2,
-      },
-      result: {
-        // 6 days ago -> penalty 12 which exceeds the 10 point cap, so zero bonus
-        dateAdded: fixedNow - 6 * 24 * 60 * 60 * 1000,
-      },
-    })
-
-    expect(score).toBeCloseTo(100)
-  })
-
-  it('requires both date-added bonus options before applying any bonus', () => {
-    const fixedNow = 1_700_000_000_000
-    jest.spyOn(Date, 'now').mockReturnValue(fixedNow)
-
-    const score = scoreFor({
-      searchTerm: 'alpha',
-      opts: {
-        scoreDateAddedBonusScoreMaximum: 10,
-        // Explicitly disable per-day penalty which previously defaulted to undefined
-        scoreDateAddedBonusScorePerDay: 0,
-      },
-      result: {
-        dateAdded: fixedNow - 12 * 60 * 60 * 1000,
-      },
-    })
-
-    expect(score).toBeCloseTo(100)
   })
 
   it('BEHAVIOR: repeated search terms each get exact tag match bonus (intentional)', () => {

--- a/popup/js/search/scoring.js
+++ b/popup/js/search/scoring.js
@@ -30,7 +30,6 @@
  * 4. ADD BEHAVIORAL BONUSES (USAGE PATTERNS)
  *    - scoreVisitedBonusScore: per visit (up to scoreVisitedBonusScoreMaximum)
  *    - scoreRecentBonusScoreMaximum: linear decay based on lastVisitSecondsAgo and historyDaysAgo
- *    - scoreDateAddedBonusScoreMaximum: linear decay based on dateAdded and scoreDateAddedBonusScorePerDay
  *
  * 5. ADD CUSTOM USER-DEFINED BONUS
  *    - scoreCustomBonusScore: extracted from "Title +20 #tag" notation (if enabled)
@@ -46,7 +45,6 @@
  * @returns {Array} Results with calculated scores
  */
 export function calculateFinalScore(results, searchTerm) {
-  const now = Date.now()
   const hasSearchTerm = Boolean(ext.model.searchTerm)
 
   // Normalize query once for all downstream checks to keep comparisons consistent and cheap.
@@ -72,8 +70,6 @@ export function calculateFinalScore(results, searchTerm) {
     scoreVisitedBonusScoreMaximum,
     scoreRecentBonusScoreMaximum,
     historyDaysAgo,
-    scoreDateAddedBonusScoreMaximum,
-    scoreDateAddedBonusScorePerDay,
     scoreCustomBonusScore,
     scoreTitleWeight,
     scoreUrlWeight,
@@ -229,15 +225,6 @@ export function calculateFinalScore(results, searchTerm) {
         // Special case: visited in this exact moment gets maximum bonus
         score += scoreRecentBonusScoreMaximum
       }
-    }
-
-    // Award bonus for recently added bookmarks (linear decay over time)
-    // Newer bookmarks score higher, older bookmarks score lower
-    // Example: added today = max bonus, added 10 days ago = max - (10 * perDayPenalty)
-    if (scoreDateAddedBonusScoreMaximum && scoreDateAddedBonusScorePerDay && el.dateAdded != null) {
-      const daysAgo = (now - el.dateAdded) / 1000 / 60 / 60 / 24
-      const penalty = daysAgo * scoreDateAddedBonusScorePerDay
-      score += Math.max(0, scoreDateAddedBonusScoreMaximum - penalty)
     }
 
     // Award bonus when bookmark already has a matching open tab (prevents duplicate opens)


### PR DESCRIPTION
Options were already removed but implementation was left-over.
I don't see value in adjusting the score by when a bookmark was added.