### PR TITLE
Fix Documentation and Markdown Inconsistencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@
 
 ## Testing Guidelines
 
-- Follow the verify loop: run `npm run lint`, then run focused Jest specs via `npm run test <file>` for fast feedback, and finish with a full `npm run test:e2e`. When the e2e suite fails, narrow it down by rerunning a single spec file (e.g. `npm run test:e2e -- tests/popup/editBookmark.spec.ts`).
+- Follow the verify loop: run `npm run lint`, then run focused Jest specs via `npm run test <file>` for fast feedback, and finish with a full `npm run test:e2e`. When the e2e suite fails, narrow it down by rerunning a single spec file (e.g. `npm run test:e2e -- tests/editBookmark.spec.js`).
 - Use Jest for deterministic unit coverage; stub DOM APIs with jsdom helpers when needed.
 - Use Playwright for integration coverage of popup interactions; keep specs independent and idempotent.
 - Name unit tests `<module>.test.js` under `__tests__` directories and describe behavior in plain language (`describe('timeSince')`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - **IMPROVED**: Search scoring precision and reliability
   - **Higher bonuses for perfect matches**: Exact matches on titles, tags, and folders now receive +20, +15, and +10 points respectively (previously +15, +10, +5), so precise results appear ahead of partial matches by default.
   - **Better multi-term query handling**: Search terms are normalized once and evaluated individually in a case-insensitive way, ensuring multi-word queries and mixed-case text reliably trigger the configured substring bonuses.
-  - **New phrase boost options**: Added `scoreExactPhraseTitleBonus` (default: 8) and `scoreExactPhraseUrlBonus` (default: 4) to boost results where the full search phrase appears as substring. For example, searching "javascript tutorial" will boost a bookmark titled "Advanced JavaScript Tutorial Guide" (+8) or with URL "example.com/javascript-tutorial" (+4).
+  - **New phrase boost options**: Added `scoreExactPhraseTitleBonus` (default: 8) and `scoreExactPhraseUrlBonus` (default: 5) to boost results where the full search phrase appears as substring. For example, searching "javascript tutorial" will boost a bookmark titled "Advanced JavaScript Tutorial Guide" (+8) or with URL "example.com/javascript-tutorial" (+5).
   - **Capped substring bonuses**: Introduced `scoreExactIncludesMaxBonuses` (default: 3) to prevent noisy documents from excessive stacking of includes bonuses.
 - **IMPROVED**: Further reduced initial load bundle size for faster startup.
 - **FIXED**: When editing a bookmark and saving, the search state was sometimes not properly updated. Now the search is completely reset, but remembers the search term.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ npm run test                   # Jest unit tests (alias of test:unit, supports e
 npm run test:unit <file>.test.js              # Run specific unit test (identical to npm run test with file)
 npm run test:unit:coverage <file>.test.js     # Run with coverage report
 npm run test:e2e               # Playwright end-to-end tests (chromium only)
-npm run test:e2e -- tests/<file>.spec.ts      # Run specific e2e test file
+npm run test:e2e -- tests/<file>.spec.js      # Run specific e2e test file
 npm run test:e2e:chromium      # Playwright for Chromium only
 npm run test:e2e:firefox       # Playwright for Firefox only
 ```
@@ -36,7 +36,7 @@ npm run test:e2e:firefox       # Playwright for Firefox only
 1. `npm run lint`
 2. `npm run test <path/to/file.test.js>` (iterate on focused Jest specs)
 3. `npm run test:e2e`
-4. If the e2e suite fails, rerun the specific spec via `npm run test:e2e -- tests/<file>.spec.ts`
+4. If the e2e suite fails, rerun the specific spec via `npm run test:e2e -- tests/<file>.spec.js`
 
 ### Build Components
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ An exemplary user config can look like the following example:
 searchStrategy: fuzzy
 displayVisitCounter: true
 historyMaxItems: 2048 # Increase max number of browser history items to load
-maxRecentTabsToShow: 32 # Limit number of recent tabs shown (default: 32)
+maxRecentTabsToShow: 32 # Limit number of recent tabs shown (default: 16)
 ```
 
 If you have **troubles with performance**, here are a few options that might help. Feel free to pick & choose and tune the values to your situation. In particular `historyMaxItems` and how many bookmarks you have will impact init and search performance.
@@ -98,7 +98,7 @@ Here is a suggestion for low-performance machines:
 ```yaml
 searchStrategy: precise # Precise search is faster than fuzzy search.
 searchMinMatchCharLength: 2 # Start searching only when at least 2 characters are entered
-displaySearchMatchHighlight: false, # Not highlighting search matches improves render performance.
+displaySearchMatchHighlight: false # Not highlighting search matches improves render performance.
 searchMaxResults: 20 # Number of search results can be further limited
 historyMaxItems: 512 # Number of browser history items can be further reduced
 maxRecentTabsToShow: 8 # Reduce number of recent tabs for better performance

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -663,7 +662,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -687,7 +685,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2611,7 +2608,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3132,7 +3128,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -3816,7 +3811,6 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5370,7 +5364,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -5586,6 +5579,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -5779,6 +5773,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6289,7 +6284,8 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "peer": true
     },
     "node_modules/readable-stream": {
       "version": "4.7.0",
@@ -6483,6 +6479,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -7575,7 +7572,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -7929,15 +7925,13 @@
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
       "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
       "dev": true,
-      "peer": true,
       "requires": {}
     },
     "@csstools/css-tokenizer": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
       "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@emnapi/core": {
       "version": "1.5.0",
@@ -9145,8 +9139,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -9474,7 +9467,6 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.3.tgz",
       "integrity": "sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==",
       "dev": true,
-      "peer": true,
       "requires": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -9928,7 +9920,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10999,7 +10990,6 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -11166,6 +11156,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -11305,7 +11296,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "peer": true
     },
     "on-headers": {
       "version": "1.1.0",
@@ -11652,7 +11644,8 @@
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "peer": true
     },
     "readable-stream": {
       "version": "4.7.0",
@@ -11787,6 +11780,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }

--- a/popup/js/search/scoring.js
+++ b/popup/js/search/scoring.js
@@ -22,7 +22,7 @@
  *      - scoreExactTagMatchBonus: tag name matches a search term (15 points default)
  *      - scoreExactFolderMatchBonus: folder name matches a search term
  *      - scoreExactPhraseTitleBonus: title contains the full search phrase (8 points default)
- *      - scoreExactPhraseUrlBonus: URL contains the full search phrase (hyphen-normalized, 4 points default)
+ *      - scoreExactPhraseUrlBonus: URL contains the full search phrase (hyphen-normalized, 5 points default)
  *    STEP 3B - Includes Bonuses (substring matching):
  *      - scoreExactIncludesBonus: weighted by field (title × 1.0, tag × 0.7, url × 0.6, folder × 0.5)
  *      - Only FIRST matching field per search term gets bonus (no double-counting)


### PR DESCRIPTION
- Update scoreExactPhraseUrlBonus default from 4 to 5 in scoring.js and CHANGELOG.md
- Correct maxRecentTabsToShow default from 32 to 16 in README.md
- Fix test file extensions from .spec.ts to .spec.js in CLAUDE.md and AGENTS.md
- Remove invalid trailing comma in YAML example in README.md

All documentation now matches actual implementation values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)