### PR TITLE
Reduce max recent tabs to show, detect more current bookmark tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [unreleased]
 
+- **CHANGE**: Default entries now exclude the currently active tab from the "recently visited" list (avoiding duplication), while ensuring it remains visible if it is bookmarked. The matching logic now also ignores anchor tags (hashes) for better discovery.
+- **CHANGE**: Reduced default `maxRecentTabsToShow` from 16 to 8 to improve performance on startup.
+
 ## [v1.17.3]
 
 - **IMPROVED**: Significant search and ranking performance through data pre-normalization

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -60,7 +60,7 @@ You can customize these options in the extension settings using YAML or JSON for
 | Option | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
 | `tabsOnlyCurrentWindow` | boolean | `false` | If true, only the current browser window is considered for tab indexing. |
-| `maxRecentTabsToShow` | number | `16` | Number of recent tabs to show when popup is opened without search term. 0 to disable. |
+| `maxRecentTabsToShow` | number | `8` | Number of recent tabs to show when popup is opened without search term. 0 to disable. |
 
 ## History Options
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ An exemplary user config can look like the following example:
 searchStrategy: fuzzy
 displayVisitCounter: true
 historyMaxItems: 2048 # Increase max number of browser history items to load
-maxRecentTabsToShow: 32 # Limit number of recent tabs shown (default: 16)
+maxRecentTabsToShow: 32 # Limit number of recent tabs shown (default: 8)
 ```
 
 If you have **troubles with performance**, here are a few options that might help. Feel free to pick & choose and tune the values to your situation. In particular `historyMaxItems` and how many bookmarks you have will impact init and search performance.
@@ -103,7 +103,7 @@ searchMinMatchCharLength: 2 # Start searching only when at least 2 characters ar
 displaySearchMatchHighlight: false # Not highlighting search matches improves render performance.
 searchMaxResults: 20 # Number of search results can be further limited
 historyMaxItems: 512 # Number of browser history items can be further reduced
-maxRecentTabsToShow: 8 # Reduce number of recent tabs for better performance
+maxRecentTabsToShow: 4 # Reduce number of recent tabs for better performance
 detectDuplicateBookmarks: false # Disable duplicate detection for faster startup (if you don't have duplicates)
 detectBookmarksWithOpenTabs: false # Disable bookmark-tab matching for faster startup (if you don't need the feature)
 ```
@@ -122,6 +122,7 @@ colorStripeWidth: 4 # Customize width of search result color stripe
 scoreTabBase: 70 # customize base score for open tabs
 detectBookmarksWithOpenTabs: true
 detectDuplicateBookmarks: true
+maxRecentTabsToShow: 4
 searchEngineChoices:
   - name: Google
     urlPrefix: https://google.com/search?q=

--- a/popup/js/model/options.js
+++ b/popup/js/model/options.js
@@ -194,7 +194,7 @@ export const defaultOptions = {
    * Number of recent tabs to show when popup is opened without search term. Set to 0 to disable.
    * Limiting this improves performance for users with many open tabs
    */
-  maxRecentTabsToShow: 16,
+  maxRecentTabsToShow: 8,
 
   //////////////////////////////////////////
   // HISTORY OPTIONS                      //


### PR DESCRIPTION
- **CHANGE**: Default entries now exclude the currently active tab from the "recently visited" list (avoiding duplication), while ensuring it remains visible if it is bookmarked. The matching logic now also ignores anchor tags (hashes) for better discovery.
- **CHANGE**: Reduced default `maxRecentTabsToShow` from 16 to 8 to improve performance on startup.
