### PR TITLE
Ignore search navigation shortcuts during IME composition

### DIFF
--- a/popup/js/view/__tests__/searchNavigation.test.js
+++ b/popup/js/view/__tests__/searchNavigation.test.js
@@ -168,6 +168,17 @@ describe('searchNavigation selection helpers', () => {
 })
 
 describe('searchNavigation navigationKeyListener', () => {
+  const imeCases = [
+    {
+      name: 'isComposing is active',
+      event: { isComposing: true },
+    },
+    {
+      name: 'legacy Process key fallback is reported',
+      event: { isComposing: false, keyCode: 229, which: 229 },
+    },
+  ]
+
   it('handles arrow navigation and prevents going above first item', async () => {
     const { module, viewModule, elements } = await setupSearchNavigation()
     await viewModule.renderSearchResults()
@@ -257,49 +268,63 @@ describe('searchNavigation navigationKeyListener', () => {
     expect(windowCloseSpy).toHaveBeenCalledTimes(1)
   })
 
-  it('ignores Enter while IME composition is active', async () => {
-    const { module, viewModule } = await setupSearchNavigation()
-    await viewModule.renderSearchResults()
+  it.each([
+    { strategy: 'precise' },
+    { strategy: 'fuzzy' },
+  ])('ignores Enter while IME composition is active in $strategy mode', async ({ strategy }) => {
+    for (const imeCase of imeCases) {
+      const { module, viewModule } = await setupSearchNavigation({
+        opts: { searchStrategy: strategy },
+      })
+      await viewModule.renderSearchResults()
 
-    const windowCloseSpy = jest.fn()
-    window.close = windowCloseSpy
+      const windowCloseSpy = jest.fn()
+      window.close = windowCloseSpy
 
-    await module.navigationKeyListener({
-      key: 'Enter',
-      isComposing: true,
-      preventDefault: jest.fn(),
-      stopPropagation: jest.fn(),
-      button: 0,
-      target: {
-        nodeName: 'LI',
-        getAttribute: () => null,
-        className: '',
-      },
-    })
+      await module.navigationKeyListener({
+        key: 'Enter',
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+        button: 0,
+        target: {
+          nodeName: 'LI',
+          getAttribute: () => null,
+          className: '',
+        },
+        ...imeCase.event,
+      })
 
-    expect(windowCloseSpy).not.toHaveBeenCalled()
-    expect(ext.model.currentItem).toBe(0)
+      expect(windowCloseSpy).not.toHaveBeenCalled()
+      expect(ext.model.currentItem).toBe(0)
+    }
   })
 
-  it('ignores navigation keys while IME composition is active', async () => {
-    const { module, viewModule, elements } = await setupSearchNavigation()
-    await viewModule.renderSearchResults()
+  it.each([
+    { strategy: 'precise' },
+    { strategy: 'fuzzy' },
+  ])('ignores navigation keys while IME composition is active in $strategy mode', async ({ strategy }) => {
+    for (const imeCase of imeCases) {
+      const { module, viewModule, elements } = await setupSearchNavigation({
+        opts: { searchStrategy: strategy },
+      })
+      await viewModule.renderSearchResults()
 
-    const preventDefault = jest.fn()
-    Array.from(elements.resultList.children).forEach((child) => {
-      child.scrollIntoView = jest.fn()
-    })
+      const preventDefault = jest.fn()
+      Array.from(elements.resultList.children).forEach((child) => {
+        child.scrollIntoView = jest.fn()
+      })
 
-    ext.model.currentItem = 0
-    await module.navigationKeyListener({
-      key: 'ArrowDown',
-      isComposing: true,
-      preventDefault,
-    })
+      ext.model.currentItem = 0
+      await module.navigationKeyListener({
+        key: 'ArrowDown',
+        preventDefault,
+        ...imeCase.event,
+      })
 
-    expect(preventDefault).not.toHaveBeenCalled()
-    expect(ext.model.currentItem).toBe(0)
-    expect(document.getElementById('sel')).toBe(elements.resultList.children[0])
+      expect(preventDefault).not.toHaveBeenCalled()
+      expect(ext.model.currentItem).toBe(0)
+      expect(document.getElementById('sel')).toBe(elements.resultList.children[0])
+    }
   })
 
   it('waits for in-flight search to complete before opening result on Enter', async () => {

--- a/popup/js/view/__tests__/searchNavigation.test.js
+++ b/popup/js/view/__tests__/searchNavigation.test.js
@@ -257,6 +257,51 @@ describe('searchNavigation navigationKeyListener', () => {
     expect(windowCloseSpy).toHaveBeenCalledTimes(1)
   })
 
+  it('ignores Enter while IME composition is active', async () => {
+    const { module, viewModule } = await setupSearchNavigation()
+    await viewModule.renderSearchResults()
+
+    const windowCloseSpy = jest.fn()
+    window.close = windowCloseSpy
+
+    await module.navigationKeyListener({
+      key: 'Enter',
+      isComposing: true,
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+      button: 0,
+      target: {
+        nodeName: 'LI',
+        getAttribute: () => null,
+        className: '',
+      },
+    })
+
+    expect(windowCloseSpy).not.toHaveBeenCalled()
+    expect(ext.model.currentItem).toBe(0)
+  })
+
+  it('ignores navigation keys while IME composition is active', async () => {
+    const { module, viewModule, elements } = await setupSearchNavigation()
+    await viewModule.renderSearchResults()
+
+    const preventDefault = jest.fn()
+    Array.from(elements.resultList.children).forEach((child) => {
+      child.scrollIntoView = jest.fn()
+    })
+
+    ext.model.currentItem = 0
+    await module.navigationKeyListener({
+      key: 'ArrowDown',
+      isComposing: true,
+      preventDefault,
+    })
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(ext.model.currentItem).toBe(0)
+    expect(document.getElementById('sel')).toBe(elements.resultList.children[0])
+  })
+
   it('waits for in-flight search to complete before opening result on Enter', async () => {
     const { module, viewModule } = await setupSearchNavigation()
     await viewModule.renderSearchResults()

--- a/popup/js/view/searchNavigation.js
+++ b/popup/js/view/searchNavigation.js
@@ -10,11 +10,24 @@
 
 import { openResultItem, toggleSearchApproach } from './searchEvents.js'
 
+// Some browsers report IME conversion keys as legacy keyCode/which 229 ("Process").
+// Treat that as composing so Enter/arrow keys used to confirm or navigate candidates
+// do not trigger extension shortcuts.
+const IME_PROCESS_KEY_CODE = 229
+
+function isImeComposing(event) {
+  return event.isComposing || event.keyCode === IME_PROCESS_KEY_CODE || event.which === IME_PROCESS_KEY_CODE
+}
+
 /**
  * Handle keyboard navigation for search results
  * Supports arrow keys and vim-style keybindings (Ctrl+P/Ctrl+N, Ctrl+K/Ctrl+J)
  */
 export async function navigationKeyListener(event) {
+  if (isImeComposing(event)) {
+    return
+  }
+
   // Define navigation directions with multiple keybinding options
   const up = event.key === 'ArrowUp' || (event.ctrlKey && event.key === 'p') || (event.ctrlKey && event.key === 'k')
   const down = event.key === 'ArrowDown' || (event.ctrlKey && event.key === 'n') || (event.ctrlKey && event.key === 'j')


### PR DESCRIPTION
## Summary

- ignore search navigation shortcuts while IME composition is active
- treat legacy `keyCode` / `which === 229` (`Process`) as composing as a fallback for browsers that do not reliably expose `isComposing`
- add regression tests to verify Enter and arrow-key navigation do not activate results or move selection during composition

## Why

I use the extension in Japanese, which requires converting text through an IME before confirming the final input.
During that conversion step, Enter and arrow keys are used to confirm or navigate IME candidates, so the extension should not treat those keys as search-result shortcuts.

Without this change, pressing Enter or arrow keys during IME composition can accidentally open a result or move the selection in the popup before the query is finalized.

## Testing

- `npx @biomejs/biome check popup/js/view/searchNavigation.js popup/js/view/__tests__/searchNavigation.test.js`
- `npm run test`
- `npm run build:update-libs`
- `npm run test:e2e`

## Results

- targeted Biome check passed
- Jest passed: 33 suites, 394 tests
- Playwright passed: 61 tests

## Notes

- `npm run lint` currently fails on pre-existing repo-wide issues unrelated to this branch, including:
  - Biome schema version mismatch in `biome.json` (`2.3.11` vs CLI `2.4.8`)
  - existing accessibility diagnostics in HTML files such as missing SVG titles and `autofocus` usage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Keyboard navigation and shortcuts now correctly detect IME (Input Method Editor) composition mode. While composing text (e.g., typing in non-Latin languages), Enter, Arrow keys and other navigation shortcuts are ignored so typing won’t trigger selection changes, activation, or accidental closing. This prevents unintended navigation or actions during character composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->