### PR TITLE
Preserve original bookmark URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,5 @@ popup/js/*.min.js*
 popup/css/*.min.css*
 
 .claude/
+.codex
 plans/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- **FIXED**: Preserve original bookmark, tab, and history URLs for display and opening, while keeping normalized URL matching for search and deduplication.
+
 ## [v2.1.1]
 
 - **IMPROVED**: Performance: Reduced repeated work in precise incremental search by skipping unchanged leading terms when a query is extended.

--- a/bin/syncDevDist.js
+++ b/bin/syncDevDist.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import fs from 'fs-extra'
+
+const SOURCE_DIST_PATH = path.resolve('dist')
+const DEV_DIST_PATH = '/mnt/c/Development/search-bookmarks-history-and-tabs/dist'
+
+/**
+ * Mirror the local build output into a second checkout when it exists.
+ *
+ * This is just convenience for the developer, so the step quietly no-ops when
+ * the extra checkout is not available.
+ */
+export async function syncDevDist() {
+  const devDistExists = await fs.pathExists(DEV_DIST_PATH)
+  if (!devDistExists) {
+    return
+  }
+
+  await fs.remove(DEV_DIST_PATH)
+  await fs.copy(SOURCE_DIST_PATH, DEV_DIST_PATH)
+  console.info(`Synced dist/ to ${DEV_DIST_PATH}`)
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  syncDevDist().catch((error) => {
+    console.error('Failed to sync dist to developer checkout')
+    console.error(error)
+    process.exit(1)
+  })
+}

--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
   "scripts": {
     "prepare": "lefthook install",
     "clean": "node bin/clean.js",
-    "build": "npm run clean && npm run build:update-libs && npm run build:bundle && npm run build:update-manifests && npm run build:create-dist && npm run format && npm run size",
+    "build": "npm run clean && npm run build:update-libs && npm run build:bundle && npm run build:update-manifests && npm run build:create-dist && npm run format && npm run size && npm run build:sync-dev-dist",
     "build:bundle": "node bin/bundle.js",
     "build:update-libs": "node bin/updateLibs.js",
     "build:create-dist": "node bin/createDist.js",
+    "build:sync-dev-dist": "node bin/syncDevDist.js",
     "build:update-manifests": "node bin/updateManifests.js",
     "benchmark": "hyperfine --warmup 2 --runs 5 --export-json hyperfine.json 'npm run clean' 'npm run lint' 'npm run format' 'npm run build' 'npm run test' 'npm run test:e2e'",
     "test": "npm run test:unit",

--- a/playwright/tests/editBookmark.spec.js
+++ b/playwright/tests/editBookmark.spec.js
@@ -197,7 +197,7 @@ test.describe('Edit Bookmark View', () => {
 
   test('prefills bookmark fields and tag list with existing data', async ({ page }) => {
     await expect(page.locator('#bm-title')).toHaveValue('Try pandoc!')
-    await expect(page.locator('#bm-url')).toHaveValue('https://pandoc.org/try')
+    await expect(page.locator('#bm-url')).toHaveValue('https://pandoc.org/try/')
 
     const tagValues = await page.evaluate(() => window.ext.tagify.value.map((tag) => tag.value))
     expect(tagValues).toEqual(['md'])

--- a/popup/js/helper/__tests__/browserApi.test.js
+++ b/popup/js/helper/__tests__/browserApi.test.js
@@ -108,7 +108,7 @@ describe('convertBrowserTabs', () => {
       type: 'tab',
       title: 'Example',
       url: 'example.com/path',
-      originalUrl: 'https://Example.com/path',
+      originalUrl: 'https://Example.com/path/',
       originalId: 5,
       active: true,
       windowId: 3,
@@ -136,7 +136,7 @@ describe('convertBrowserTabs', () => {
     expect(result[0]).toMatchObject({
       originalId: 4,
       url: 'valid.example.com',
-      originalUrl: 'https://valid.example.com',
+      originalUrl: 'https://valid.example.com/',
     })
   })
 })
@@ -208,7 +208,7 @@ describe('convertBrowserBookmarks', () => {
       originalId: 'bookmark-1',
       title: 'Example',
       url: 'example.com',
-      originalUrl: 'https://Example.com',
+      originalUrl: 'https://Example.com/',
       dateAdded: 123,
       customBonusScore: 5,
       tags: '#tag1 #tag2',
@@ -395,6 +395,25 @@ describe('convertBrowserHistory', () => {
       visitCount: 3,
       lastVisitSecondsAgo: 1,
       searchStringLower: 'keep¦keep.example.com/page',
+    })
+  })
+
+  it('preserves trailing slashes in history originalUrl', () => {
+    const history = [
+      {
+        id: '1',
+        url: 'https://keep.example.com/page/',
+        title: 'Keep',
+        visitCount: 3,
+        lastVisitTime: 9_000,
+      },
+    ]
+
+    const [entry] = convertBrowserHistory(history)
+
+    expect(entry).toMatchObject({
+      url: 'keep.example.com/page',
+      originalUrl: 'https://keep.example.com/page/',
     })
   })
 

--- a/popup/js/helper/browserApi.js
+++ b/popup/js/helper/browserApi.js
@@ -1,6 +1,5 @@
 const BONUS_SCORE_REGEX = /[ ][+]([0-9]+)/
 const TAG_NUMERIC_CHECK_REGEX = /^\d/
-const URL_ROOT_CLEANUP_REGEX = /\/$/
 const REGEX_SPECIAL_CHARS_REGEX = /[.*+?^${}()|[\]/-]/g
 
 /**
@@ -10,7 +9,7 @@ const REGEX_SPECIAL_CHARS_REGEX = /[.*+?^${}()|[\]/-]/g
  * - Fetch raw entries with defensive fallbacks for browsers that omit certain APIs.
  * - Convert every record into the shared `searchItem` shape (type, title, url, tags, folder trail, search strings).
  * - Parse inline annotations like `#tag` taxonomy markers and `+20` custom bonus hints from bookmark titles.
- * - Clean URLs/titles by stripping protocol, `www`, and trailing slashes to stabilize comparisons and cache keys.
+ * - Preserve source URLs exactly while also deriving normalized URL keys for search, comparisons, and dedupe.
  * - Preserve breadcrumb-style folder metadata so taxonomy pages and scoring rules stay in sync across browsers.
  */
 
@@ -100,7 +99,7 @@ export function convertBrowserTabs(chromeTabs, groupMap) {
         title,
         titleLower: titleLower,
         url: cleanUrl,
-        originalUrl: el.url.replace(URL_ROOT_CLEANUP_REGEX, ''),
+        originalUrl: el.url,
         originalId: el.id,
         favIconUrl: el.favIconUrl,
         active: el.active,
@@ -192,8 +191,8 @@ export function convertBrowserBookmarks(
         }
       }
 
-      const url = entry.url.replace(URL_ROOT_CLEANUP_REGEX, '')
-      const cleanedUrl = cleanUpUrl(url)
+      const originalUrl = entry.url
+      const cleanedUrl = cleanUpUrl(originalUrl)
 
       // Parse out tags from bookmark title (starting with " #")
       let tagsText = ''
@@ -225,7 +224,7 @@ export function convertBrowserBookmarks(
         originalId: entry.id,
         title: finalTitle,
         titleLower: titleLower,
-        originalUrl: url,
+        originalUrl,
         url: cleanedUrl,
         dateAdded: entry.dateAdded,
         customBonusScore,
@@ -242,7 +241,7 @@ export function convertBrowserBookmarks(
 
       // Add favicon URL for Chrome (uses _favicon API)
       if (ext.opts.displayFavicons) {
-        const faviconUrl = getFaviconUrl(url)
+        const faviconUrl = getFaviconUrl(originalUrl)
         if (faviconUrl) {
           mappedEntry.favIconUrl = faviconUrl
         }
@@ -382,7 +381,7 @@ export function convertBrowserHistory(history) {
       type: 'history',
       title,
       titleLower: titleLower,
-      originalUrl: el.url.replace(URL_ROOT_CLEANUP_REGEX, ''),
+      originalUrl: el.url,
       url: cleanUrl,
       visitCount: el.visitCount,
       lastVisitSecondsAgo: (now - el.lastVisitTime) / 1000,

--- a/popup/js/helper/utils.js
+++ b/popup/js/helper/utils.js
@@ -145,7 +145,7 @@ const URL_CLEANUP_TRAILING_SLASH_REGEX = /\/$/
  *
  * Strips http://, https://, www. prefix and converts to lowercase
  * to enable consistent URL comparison across different URL formats.
- * Used for matching bookmarks/history to current page and for display.
+ * Used for matching, deduplication, and search indexing.
  *
  * @param {string|null} url - URL to normalize
  * @returns {string} Normalized URL (lowercase, no protocol/www/trailing slash/hash)

--- a/popup/js/model/searchData.js
+++ b/popup/js/model/searchData.js
@@ -23,7 +23,7 @@ import {
  * Efficiently merges history data into bookmarks or tabs using lazy evaluation
  * Only creates new objects when there are actual history matches to merge
  * @param {Array} items - Array of bookmarks or tabs
- * @param {Map} historyMap - Map of URL to history item
+ * @param {Map} historyMap - Map of normalized URL to history item
  * @param {Set<string>} [mergedUrls] - Tracks which history URLs were merged
  * @returns {Array} - Merged array with history data
  */
@@ -35,11 +35,11 @@ function mergeHistoryLazily(items, historyMap, mergedUrls) {
 
   for (let i = 0; i < items.length; i++) {
     const item = items[i]
-    const historyEntry = historyMap.get(item.originalUrl)
+    const historyEntry = historyMap.get(item.url)
 
     if (historyEntry) {
       if (mergedUrls) {
-        mergedUrls.add(item.originalUrl)
+        mergedUrls.add(historyEntry.originalUrl)
       }
       result[i] = {
         ...item,
@@ -146,7 +146,7 @@ export async function getSearchData() {
     // Merge history data into bookmarks and tabs if history is enabled
     if (browserApi.history && ext.opts.enableHistory && result.history.length > 0) {
       // Build maps with URL as key, so we have fast hashmap access
-      const historyMap = new Map(result.history.map((item) => [item.originalUrl, item]))
+      const historyMap = new Map(result.history.map((item) => [item.url, item]))
 
       const mergedHistoryUrls = new Set()
 

--- a/popup/js/search/common.js
+++ b/popup/js/search/common.js
@@ -445,7 +445,7 @@ function highlightResults(results, searchTerm) {
     const entry = results[i]
 
     entry.highlightedTitle = highlightMatches(entry.title || entry.url, highlightRegex)
-    entry.highlightedUrl = highlightMatches(entry.url, highlightRegex)
+    entry.highlightedUrl = highlightMatches(entry.originalUrl || entry.url, highlightRegex)
 
     const tagsArray = entry.tagsArray
     if (highlightTags && tagsArray) {

--- a/popup/js/view/__tests__/searchEvents.test.js
+++ b/popup/js/view/__tests__/searchEvents.test.js
@@ -413,6 +413,68 @@ describe('searchEvents openResultItem', () => {
     expect(window.close).toHaveBeenCalledTimes(1)
   })
 
+  it('prefers matching tabs by originalId before normalized URL', async () => {
+    const tabResults = [
+      {
+        type: 'tab',
+        originalId: 100,
+        originalUrl: 'https://example.test/page#one',
+        url: 'example.test/page',
+        title: 'First tab',
+        score: 10,
+      },
+      {
+        type: 'tab',
+        originalId: 200,
+        originalUrl: 'https://example.test/page#two',
+        url: 'example.test/page',
+        title: 'Second tab',
+        score: 9,
+      },
+    ]
+
+    const { module, viewModule, navigationModule } = await setupSearchEvents({
+      results: tabResults,
+    })
+    await viewModule.renderSearchResults()
+    navigationModule.selectListItem(1)
+
+    ext.model.tabs = [
+      {
+        originalId: 100,
+        originalUrl: 'https://example.test/page#one',
+        url: 'example.test/page',
+        windowId: 101,
+      },
+      {
+        originalId: 200,
+        originalUrl: 'https://example.test/page#two',
+        url: 'example.test/page',
+        windowId: 202,
+      },
+    ]
+
+    module.openResultItem({
+      button: 0,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      target: {
+        nodeName: 'LI',
+        getAttribute: () => null,
+        className: '',
+      },
+      stopPropagation: jest.fn(),
+      preventDefault: jest.fn(),
+    })
+
+    expect(ext.browserApi.tabs.update).toHaveBeenCalledWith(200, { active: true })
+    expect(ext.browserApi.windows.update).toHaveBeenCalledWith(202, {
+      focused: true,
+    })
+    expect(ext.browserApi.tabs.create).not.toHaveBeenCalled()
+  })
+
   it('matches existing tabs by normalized URL when originalUrl formatting differs', async () => {
     const { module, viewModule } = await setupSearchEvents({
       results: [

--- a/popup/js/view/__tests__/searchEvents.test.js
+++ b/popup/js/view/__tests__/searchEvents.test.js
@@ -74,6 +74,7 @@ async function setupSearchEvents({ results = createResults(), opts = {} } = {}) 
     .map((entry) => ({
       originalId: entry.originalId,
       originalUrl: entry.originalUrl,
+      url: entry.url,
       windowId: 101,
     }))
 
@@ -410,6 +411,48 @@ describe('searchEvents openResultItem', () => {
       focused: true,
     })
     expect(window.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('matches existing tabs by normalized URL when originalUrl formatting differs', async () => {
+    const { module, viewModule } = await setupSearchEvents({
+      results: [
+        {
+          type: 'bookmark',
+          originalId: 'bm-1',
+          originalUrl: 'https://bookmark.test/',
+          url: 'bookmark.test',
+          title: 'Bookmark Title',
+          score: 10,
+        },
+      ],
+    })
+    await viewModule.renderSearchResults()
+
+    ext.model.tabs = [
+      {
+        originalId: 22,
+        originalUrl: 'https://bookmark.test',
+        url: 'bookmark.test',
+        windowId: 101,
+      },
+    ]
+
+    module.openResultItem({
+      button: 0,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      target: {
+        nodeName: 'LI',
+        getAttribute: () => null,
+        className: '',
+      },
+      stopPropagation: jest.fn(),
+      preventDefault: jest.fn(),
+    })
+
+    expect(ext.browserApi.tabs.update).toHaveBeenCalledWith(22, { active: true })
+    expect(ext.browserApi.tabs.create).not.toHaveBeenCalled()
   })
 
   it('opens a new active tab when no matching tab exists', async () => {

--- a/popup/js/view/__tests__/searchView.test.js
+++ b/popup/js/view/__tests__/searchView.test.js
@@ -252,8 +252,29 @@ describe('searchView renderSearchResults', () => {
     expect(folderBadge.innerHTML).toContain('&lt;img src=x&gt;')
 
     const urlDiv = listItem.querySelector('.url')
-    expect(urlDiv.textContent).toBe('example.com/<iframe src=javascript:alert(1)>')
-    expect(urlDiv.innerHTML).toContain('&lt;iframe src=javascript:alert(1)&gt;')
+    expect(urlDiv.textContent).toBe('https://example.com/<script>alert(1)</script>')
+    expect(urlDiv.innerHTML).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+  })
+
+  it('renders the preserved original URL instead of the normalized comparison key', async () => {
+    const { module, elements } = await setupSearchView({
+      results: [
+        {
+          type: 'bookmark',
+          originalId: 'bm-slash',
+          originalUrl: 'https://example.com/path/',
+          url: 'example.com/path',
+          title: 'Slash Bookmark',
+        },
+      ],
+      opts: { displaySearchMatchHighlight: false },
+    })
+
+    await module.renderSearchResults()
+
+    const urlDiv = elements.resultList.querySelector('.url')
+    expect(urlDiv.textContent).toBe('https://example.com/path/')
+    expect(urlDiv.getAttribute('title')).toBe('https://example.com/path/')
   })
 
   it('handles results without optional fields gracefully', async () => {

--- a/popup/js/view/searchEvents.js
+++ b/popup/js/view/searchEvents.js
@@ -11,6 +11,7 @@
 
 import { getUserOptions, setUserOptions } from '../model/options.js'
 import { search } from '../search/common.js'
+import { cleanUpUrl } from '../helper/utils.js'
 import { clearSelection, hoverResultItem } from './searchNavigation.js'
 import { renderSearchResults } from './searchView.js'
 
@@ -110,6 +111,7 @@ export function openResultItem(event) {
 
   // Final fallback to DOM attributes if model state is unavailable
   const url = selectedResult?.originalUrl ?? resultEntry?.getAttribute('x-open-url')
+  const normalizedUrl = selectedResult?.url ?? (url ? cleanUpUrl(url) : '')
 
   // Handle right-click to copy URL to clipboard
   if (event.button === 2) {
@@ -161,7 +163,7 @@ export function openResultItem(event) {
 
   // Default behavior - open in new tab or switch to existing tab
   const foundTab = ext.model.tabs.find((el) => {
-    return el.originalUrl === url
+    return el.url === normalizedUrl
   })
 
   if (foundTab && ext.browserApi.tabs.highlight) {

--- a/popup/js/view/searchEvents.js
+++ b/popup/js/view/searchEvents.js
@@ -9,9 +9,9 @@
  * - Coordinate with search and navigation modules for result interactions.
  */
 
+import { cleanUpUrl } from '../helper/utils.js'
 import { getUserOptions, setUserOptions } from '../model/options.js'
 import { search } from '../search/common.js'
-import { cleanUpUrl } from '../helper/utils.js'
 import { clearSelection, hoverResultItem } from './searchNavigation.js'
 import { renderSearchResults } from './searchView.js'
 
@@ -162,9 +162,16 @@ export function openResultItem(event) {
   }
 
   // Default behavior - open in new tab or switch to existing tab
-  const foundTab = ext.model.tabs.find((el) => {
-    return el.url === normalizedUrl
-  })
+  let foundTab = null
+  if (selectedResult?.type === 'tab' && selectedResult.originalId != null) {
+    foundTab = ext.model.tabs.find((el) => el.originalId === selectedResult.originalId)
+  }
+
+  if (!foundTab) {
+    foundTab = ext.model.tabs.find((el) => {
+      return el.url === normalizedUrl
+    })
+  }
 
   if (foundTab && ext.browserApi.tabs.highlight) {
     // Switch to existing tab if found

--- a/popup/js/view/searchView.js
+++ b/popup/js/view/searchView.js
@@ -145,7 +145,8 @@ export async function renderSearchResults() {
 
       const title =
         shouldHighlight && entry.highlightedTitle ? entry.highlightedTitle : escapeHtml(entry.title || entry.url || '')
-      const url = shouldHighlight && entry.highlightedUrl ? entry.highlightedUrl : escapeHtml(entry.url || '')
+      const displayUrl = entry.originalUrl || entry.url || ''
+      const url = shouldHighlight && entry.highlightedUrl ? entry.highlightedUrl : escapeHtml(displayUrl)
 
       let colorStyle = `border-left-color: ${typeColors[type] || ''}`
       if (type === 'bookmark' && entry.tab) {
@@ -166,7 +167,7 @@ export async function renderSearchResults() {
       }
 
       itemsHTML.push(
-        `<li class="${escapeHtml(type)}"${originalUrl} x-index="${i}"${originalId} style="${colorStyle}">${type === 'bookmark' ? `<img class="edit" x-link="./editBookmark.html#bookmark/${encodeURIComponent(entry.originalId)}${searchTermSuffix}" title="Edit Bookmark" src="./img/edit.svg">` : ''}${type === 'tab' ? '<img class="close" title="Close Tab" src="./img/x.svg">' : ''}<div class="title">${faviconHtml}<span class="title-text">${title} </span>${badges.join('')}</div><div class="url" title="${escapeHtml(entry.url || '')}">${url}</div></li>`,
+        `<li class="${escapeHtml(type)}"${originalUrl} x-index="${i}"${originalId} style="${colorStyle}">${type === 'bookmark' ? `<img class="edit" x-link="./editBookmark.html#bookmark/${encodeURIComponent(entry.originalId)}${searchTermSuffix}" title="Edit Bookmark" src="./img/edit.svg">` : ''}${type === 'tab' ? '<img class="close" title="Close Tab" src="./img/x.svg">' : ''}<div class="title">${faviconHtml}<span class="title-text">${title} </span>${badges.join('')}</div><div class="url" title="${escapeHtml(displayUrl)}">${url}</div></li>`,
       )
     }
 


### PR DESCRIPTION
Resolves #329 

**FIXED**: Preserve original bookmark, tab, and history URLs for display and opening, while keeping normalized URL matching for search and deduplication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * URLs in bookmarks, tabs, and history now display in their original format, preserving details such as trailing slashes. Search results and duplicate detection continue to function accurately with normalized URL matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->