### PR TITLE
feature: add openInCurrentTab configuration option

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -14,6 +14,7 @@ For advanced users, you can also inspect the [JSON Schema](https://raw.githubuse
 | `searchStrategy` | string | `'precise'` | Search approach: `'precise'` (faster, only exact matches) or `'fuzzy'` (slower, finds approximate matches using [uFuzzy](https://github.com/leeoniya/uFuzzy)). |
 | `searchMaxResults` | integer | `24` | Maximum number of search results to display. Lower values improve performance. Does not apply to tag and folder search (which show all matches). |
 | `searchFuzzyness` | number | `0.6` | Fuzzy search tolerance (0–1). Higher values find more approximate matches but may return less relevant results. Only applies when `searchStrategy` is `'fuzzy'`. |
+| `openInCurrentTab` | boolean | `false` | Open results in the current tab by default. When enabled, hold `Shift` or `Alt` to open in a new tab instead (inverts the default behavior). |
 
 ## Colors and Style
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Click a screenshot to open it full size:
   - Hold `Shift` or `Alt` to open the result in the current tab.
   - Hold `Ctrl` to open the result without closing the popup.
   - Right-click to copy URL to clipboard.
+  - Prefer opening in the current tab? Enable the `openInCurrentTab` option to make that the default; `Shift`/`Alt` then opens in a new tab instead.
 - **Search Modes**: In case you want to be more selective -> use a search mode:
   - Start your query with `#`: only **bookmarks with the tag** will be returned (exact "starts with" search)
     - Supports AND search, e.g. search for `#github #pr` to only get results which have both tags

--- a/Tips.md
+++ b/Tips.md
@@ -11,6 +11,7 @@
   - <kbd>Enter</kbd>: Open in new active tab (or switch to existing tab).
   - <kbd>Shift</kbd> + <kbd>Enter</kbd> or <kbd>Alt</kbd> + <kbd>Enter</kbd>: Open in **current tab**.
   - <kbd>Ctrl</kbd> + <kbd>Enter</kbd>: Open in background without closing the popup.
+  - Tip: Enable the `openInCurrentTab` option to flip this — <kbd>Enter</kbd> opens in the **current tab** and <kbd>Shift</kbd>/<kbd>Alt</kbd> + <kbd>Enter</kbd> opens in a **new tab**.
 - **Copy URL**: **Right-Click** any result or press a custom shortcut if configured.
 - **Hybrid Search**: Press <kbd>TAB</kbd> to insert a double-space separator for combining taxonomy filters with search terms (e.g., `#tag  query`).
 

--- a/popup/js/model/optionsDefaults.js
+++ b/popup/js/model/optionsDefaults.js
@@ -23,6 +23,11 @@ export const defaultOptions = {
   searchMaxResults: 24,
   /** Fuzzy search threshold (0-1). 0 = no fuzzyness, 1 = full fuzzyness */
   searchFuzzyness: 0.6,
+  /**
+   * Open results in the current tab by default.
+   * When enabled, hold Shift/Alt to open in a new tab instead (the opposite of the default behavior).
+   */
+  openInCurrentTab: false,
 
   //////////////////////////////////////////
   // COLORS AND STYLE                     //

--- a/popup/js/view/__tests__/searchEvents.test.js
+++ b/popup/js/view/__tests__/searchEvents.test.js
@@ -565,6 +565,91 @@ describe('searchEvents openResultItem', () => {
     expect(window.open).toHaveBeenCalledWith('https://bookmark.test', '_newtab')
   })
 
+  it('opens in the current tab on a plain click when openInCurrentTab is enabled', async () => {
+    const { module, viewModule } = await setupSearchEvents({ opts: { openInCurrentTab: true } })
+    await viewModule.renderSearchResults()
+    ext.model.tabs = []
+
+    module.openResultItem({
+      button: 0,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      target: {
+        nodeName: 'LI',
+        getAttribute: () => null,
+        className: '',
+      },
+      stopPropagation: jest.fn(),
+      preventDefault: jest.fn(),
+    })
+    await Promise.resolve()
+
+    expect(ext.browserApi.tabs.query).toHaveBeenCalledTimes(1)
+    expect(ext.browserApi.tabs.update).toHaveBeenCalledWith(77, {
+      url: 'https://bookmark.test',
+    })
+    expect(ext.browserApi.tabs.create).not.toHaveBeenCalled()
+    expect(window.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens in a new tab when Shift is held and openInCurrentTab is enabled', async () => {
+    const { module, viewModule } = await setupSearchEvents({ opts: { openInCurrentTab: true } })
+    await viewModule.renderSearchResults()
+    ext.model.tabs = []
+
+    module.openResultItem({
+      button: 0,
+      ctrlKey: false,
+      shiftKey: true,
+      altKey: false,
+      target: {
+        nodeName: 'LI',
+        getAttribute: () => null,
+        className: '',
+      },
+      stopPropagation: jest.fn(),
+      preventDefault: jest.fn(),
+    })
+    await Promise.resolve()
+
+    expect(ext.browserApi.tabs.create).toHaveBeenCalledWith({
+      active: true,
+      url: 'https://bookmark.test',
+    })
+    expect(ext.browserApi.tabs.update).not.toHaveBeenCalled()
+    expect(window.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens in a background tab when Ctrl is held even if openInCurrentTab is enabled', async () => {
+    const { module, viewModule } = await setupSearchEvents({ opts: { openInCurrentTab: true } })
+    await viewModule.renderSearchResults()
+    ext.model.tabs = []
+
+    module.openResultItem({
+      button: 0,
+      ctrlKey: true,
+      shiftKey: false,
+      altKey: false,
+      target: {
+        nodeName: 'LI',
+        getAttribute: () => null,
+        className: '',
+      },
+      stopPropagation: jest.fn(),
+      preventDefault: jest.fn(),
+    })
+    await Promise.resolve()
+
+    expect(ext.browserApi.tabs.create).toHaveBeenCalledWith({
+      active: false,
+      url: 'https://bookmark.test',
+    })
+    expect(ext.browserApi.tabs.update).not.toHaveBeenCalled()
+    expect(ext.browserApi.tabs.query).not.toHaveBeenCalled()
+    expect(window.close).not.toHaveBeenCalled()
+  })
+
   it('reads result data from model state instead of stale DOM attributes (BUG: race condition fix)', async () => {
     const { module, viewModule } = await setupSearchEvents()
     await viewModule.renderSearchResults()

--- a/popup/js/view/searchEvents.js
+++ b/popup/js/view/searchEvents.js
@@ -119,8 +119,29 @@ export function openResultItem(event) {
     return
   }
 
-  // Handle Shift/Alt modifiers - open in current tab
-  if (event.shiftKey || event.altKey) {
+  // Handle Ctrl modifier - always open in background tab, regardless of the
+  // `openInCurrentTab` option.
+  if (event.ctrlKey) {
+    if (ext.browserApi.tabs) {
+      ext.browserApi.tabs.create({
+        active: false,
+        url: url,
+      })
+    } else {
+      window.open(url, '_newtab')
+    }
+    return
+  }
+
+  // Decide whether to open in the current tab.
+  // By default, Shift/Alt opens links in the current tab. When the
+  // `openInCurrentTab` option is enabled this is inverted: a plain click opens
+  // in the current tab and Shift/Alt opens in a new tab instead.
+  const alternateTabModifier = event.shiftKey || event.altKey
+  const useCurrentTab = ext.opts.openInCurrentTab ? !alternateTabModifier : alternateTabModifier
+
+  // Open in current tab
+  if (useCurrentTab) {
     if (ext.browserApi.tabs) {
       // Use browser tabs API to update current tab
       ext.browserApi.tabs
@@ -133,30 +154,13 @@ export function openResultItem(event) {
             ext.browserApi.tabs.update(tabs[0].id, {
               url: url,
             })
-
-            // Close popup unless Ctrl is also pressed
-            if (!event.ctrlKey) {
-              window.close()
-            }
+            window.close()
           }
         })
         .catch(console.error)
     } else {
       // Fallback for non-extension environments
       window.location.href = url
-    }
-    return
-  }
-
-  // Handle Ctrl modifier - open in background tab
-  if (event.ctrlKey) {
-    if (ext.browserApi.tabs) {
-      ext.browserApi.tabs.create({
-        active: false,
-        url: url,
-      })
-    } else {
-      window.open(url, '_newtab')
     }
     return
   }

--- a/popup/json/options.schema.json
+++ b/popup/json/options.schema.json
@@ -31,6 +31,12 @@
       "description": "How tolerant fuzzy search should be. 0 behaves like precise search; values closer to 1 allow more relaxed matches.",
       "x-ui-section": "search"
     },
+    "openInCurrentTab": {
+      "type": "boolean",
+      "default": false,
+      "description": "Open results in the current tab by default. When enabled, hold Shift or Alt to open in a new tab instead, inverting the usual behavior.",
+      "x-ui-section": "search"
+    },
     "bookmarkColor": {
       "type": "string",
       "pattern": "^#([0-9a-fA-F]{3}){1,2}$",


### PR DESCRIPTION
This closes #349 with a new `openInCurrentTab` option that is defaulted to the existing user experience.