### PR TITLE
Fix search initialization routing

### DIFF
--- a/popup/js/__tests__/initSearch.test.js
+++ b/popup/js/__tests__/initSearch.test.js
@@ -103,6 +103,14 @@ const mockDependencies = async (overrides = {}) => {
   return config
 }
 
+const createDeferred = () => {
+  let resolve
+  const promise = new Promise((promiseResolve) => {
+    resolve = promiseResolve
+  })
+  return { promise, resolve }
+}
+
 describe('initSearch entry point', () => {
   let moduleUnderTest
 
@@ -134,6 +142,56 @@ describe('initSearch entry point', () => {
     expect(module.ext.searchCache instanceof Map).toBe(true)
     expect(mocks.addDefaultEntries).toHaveBeenCalled()
     expect(mocks.renderSearchResults).toHaveBeenCalled()
+    expect(document.getElementById('results-load')).toBeNull()
+  })
+
+  test('initExtension keeps loading indicator until default route rendering completes', async () => {
+    const defaultEntries = createDeferred()
+    const mocks = await mockDependencies({
+      addDefaultEntries: jest.fn(() => defaultEntries.promise),
+    })
+
+    const module = await import('../initSearch.js')
+    moduleUnderTest = module
+    await flushPromises()
+
+    expect(mocks.addDefaultEntries).toHaveBeenCalled()
+    expect(mocks.renderSearchResults).not.toHaveBeenCalled()
+    expect(document.getElementById('results-load')).not.toBeNull()
+
+    defaultEntries.resolve([{ originalId: 'default' }])
+    await flushPromises()
+
+    expect(mocks.renderSearchResults).toHaveBeenCalled()
+    expect(document.getElementById('results-load')).toBeNull()
+  })
+
+  test('initExtension surfaces async hashRouter failures through the initialization catch', async () => {
+    const routeError = new Error('Default entries failed')
+    const mocks = await mockDependencies({
+      addDefaultEntries: jest.fn(() => Promise.reject(routeError)),
+    })
+
+    const module = await import('../initSearch.js')
+    moduleUnderTest = module
+    await flushPromises()
+
+    expect(mocks.printError).toHaveBeenCalledWith(routeError, 'Could not initialize Extension')
+    expect(module.ext.initialized).toBe(false)
+    expect(document.getElementById('results-load')).toBeNull()
+  })
+
+  test('initExtension removes loading indicator when search data loading fails', async () => {
+    const dataError = new Error('Search data failed')
+    const mocks = await mockDependencies({
+      getSearchData: jest.fn(() => Promise.reject(dataError)),
+    })
+
+    const module = await import('../initSearch.js')
+    moduleUnderTest = module
+    await flushPromises()
+
+    expect(mocks.printError).toHaveBeenCalledWith(dataError, 'Could not initialize Extension')
     expect(document.getElementById('results-load')).toBeNull()
   })
 

--- a/popup/js/__tests__/initSearch.test.js
+++ b/popup/js/__tests__/initSearch.test.js
@@ -166,15 +166,42 @@ describe('initSearch entry point', () => {
     expect(document.getElementById('results-load')).toBeNull()
   })
 
-  test('initExtension surfaces async hashRouter failures through the initialization catch', async () => {
-    const routeError = new Error('Default entries failed')
+  test('initExtension keeps loading indicator until hash-driven search completes', async () => {
+    const search = createDeferred()
     const mocks = await mockDependencies({
-      addDefaultEntries: jest.fn(() => Promise.reject(routeError)),
+      search: jest.fn(() => search.promise),
     })
+    window.location.hash = '#search/test'
 
     const module = await import('../initSearch.js')
     moduleUnderTest = module
     await flushPromises()
+
+    expect(mocks.search).toHaveBeenCalledWith({ bypassInitializedGuard: true })
+    expect(document.getElementById('results-load')).not.toBeNull()
+
+    search.resolve()
+    await flushPromises()
+
+    expect(document.getElementById('results-load')).toBeNull()
+  })
+
+  test('initExtension surfaces async hashRouter failures through the initialization catch', async () => {
+    const routeError = new Error('Default entries failed')
+    const mocks = await mockDependencies()
+
+    const module = await import('../initSearch.js')
+    moduleUnderTest = module
+    await flushPromises()
+
+    setupDom()
+    mocks.printError.mockClear()
+    mocks.addDefaultEntries.mockRejectedValueOnce(routeError)
+    module.ext.initialized = false
+
+    await module.initExtension().catch((err) => {
+      mocks.printError(err, 'Could not initialize Extension')
+    })
 
     expect(mocks.printError).toHaveBeenCalledWith(routeError, 'Could not initialize Extension')
     expect(module.ext.initialized).toBe(false)

--- a/popup/js/initSearch.js
+++ b/popup/js/initSearch.js
@@ -101,7 +101,7 @@ export async function hashRouter() {
     if (searchTerm) {
       ext.dom.searchInput.value = searchTerm
       ext.dom.searchInput.focus()
-      search({ bypassInitializedGuard: true })
+      await search({ bypassInitializedGuard: true })
     } else {
       // Empty search term, show default entries
       ext.dom.searchInput.value = ''

--- a/popup/js/initSearch.js
+++ b/popup/js/initSearch.js
@@ -40,45 +40,44 @@ initExtension().catch((err) => {
  */
 export async function initExtension() {
   const startTime = Date.now()
-  // Load effective options, including user customizations
-  ext.opts = await getEffectiveOptions()
+  try {
+    // Load effective options, including user customizations
+    ext.opts = await getEffectiveOptions()
 
-  // HTML Element selectors
+    // HTML Element selectors
 
-  ext.dom.searchInput = document.getElementById('q')
-  ext.dom.resultList = document.getElementById('results')
-  ext.dom.resultCounter = document.getElementById('counter')
-  ext.dom.searchApproachToggle = document.getElementById('toggle')
+    ext.dom.searchInput = document.getElementById('q')
+    ext.dom.resultList = document.getElementById('results')
+    ext.dom.resultCounter = document.getElementById('counter')
+    ext.dom.searchApproachToggle = document.getElementById('toggle')
 
-  updateSearchApproachToggle()
+    updateSearchApproachToggle()
 
-  // Load bookmarks, tabs, and history data for searching
-  Object.assign(ext.model, await getSearchData())
+    // Load bookmarks, tabs, and history data for searching
+    Object.assign(ext.model, await getSearchData())
 
-  // Register Events
-  document.addEventListener('keydown', navigationKeyListener)
-  window.addEventListener('hashchange', hashRouter, false)
-  ext.dom.searchApproachToggle.addEventListener('mouseup', toggleSearchApproach)
+    // Register Events
+    document.addEventListener('keydown', navigationKeyListener)
+    window.addEventListener('hashchange', hashRouter, false)
+    ext.dom.searchApproachToggle.addEventListener('mouseup', toggleSearchApproach)
 
-  // Run a search on every input event instead of debouncing. The popup dataset is small
-  // enough that the simpler approach keeps navigation in sync with what the user sees,
-  // avoiding stale selections when Enter is pressed quickly after typing.
-  ext.dom.searchInput.addEventListener('input', search)
+    // Run a search on every input event instead of debouncing. The popup dataset is small
+    // enough that the simpler approach keeps navigation in sync with what the user sees,
+    // avoiding stale selections when Enter is pressed quickly after typing.
+    ext.dom.searchInput.addEventListener('input', search)
 
-  // Cache search results by (term, strategy, mode) to avoid re-running algorithms
-  ext.searchCache = new Map()
-  // Track successfully loaded favicon URLs to prevent fade-in on re-renders
-  ext.model.loadedFavicons = new Set()
+    // Cache search results by (term, strategy, mode) to avoid re-running algorithms
+    ext.searchCache = new Map()
+    // Track successfully loaded favicon URLs to prevent fade-in on re-renders
+    ext.model.loadedFavicons = new Set()
 
-  ext.initialized = true
+    await hashRouter()
+    ext.initialized = true
+  } finally {
+    document.getElementById('results-load')?.remove()
 
-  hashRouter()
-
-  if (document.getElementById('results-load')) {
-    document.getElementById('results-load').remove()
+    console.debug(`Init in ${Date.now() - startTime}ms`)
   }
-
-  console.debug(`Init in ${Date.now() - startTime}ms`)
 }
 
 //////////////////////////////////////////
@@ -102,7 +101,7 @@ export async function hashRouter() {
     if (searchTerm) {
       ext.dom.searchInput.value = searchTerm
       ext.dom.searchInput.focus()
-      search()
+      search({ bypassInitializedGuard: true })
     } else {
       // Empty search term, show default entries
       ext.dom.searchInput.value = ''

--- a/popup/js/search/__tests__/common.test.js
+++ b/popup/js/search/__tests__/common.test.js
@@ -216,6 +216,15 @@ describe('search', () => {
     expect(mockRenderSearchResults).not.toHaveBeenCalled()
   })
 
+  test('allows router-driven search during initialization', async () => {
+    ext.initialized = false
+    ext.dom.searchInput.value = 'Test'
+
+    await search({ bypassInitializedGuard: true })
+
+    expect(mockRenderSearchResults).toHaveBeenCalledWith()
+  })
+
   test('uses cached results when present', async () => {
     const cached = [{ type: 'bookmark', score: 50 }]
     ext.searchCache = new Map([['test_precise_all', cached]])

--- a/popup/js/search/common.js
+++ b/popup/js/search/common.js
@@ -286,7 +286,7 @@ function cacheResults(searchTerm, results) {
 /**
  * Execute a search against the cached datasets based on the current UI state.
  *
- * @param {KeyboardEvent|InputEvent} [event] - Optional input event from the search field.
+ * @param {KeyboardEvent|InputEvent|{bypassInitializedGuard?: boolean}} [event] - Optional input event from the search field.
  * @returns {Promise<void>}
  */
 export async function search(event) {
@@ -296,7 +296,7 @@ export async function search(event) {
   const searchPromise = (async () => {
     const startTime = Date.now()
     try {
-      if (shouldSkipSearch(event) || !ext.initialized) return
+      if (shouldSkipSearch(event) || (!ext.initialized && !event?.bypassInitializedGuard)) return
 
       if (typeof performance !== 'undefined' && typeof performance.mark === 'function') {
         performance.mark('search-start')


### PR DESCRIPTION
## Summary
- Awaits hash routing during popup initialization so default rendering and route errors are handled before initialization completes.
- Keeps the loading indicator visible until the initial route finishes and removes it on failures.
- Allows router-driven searches to bypass the initialization guard.

## Checks
- npm run test:unit -- popup/js/__tests__/initSearch.test.js popup/js/search/__tests__/common.test.js
- npm run lint