### PR TITLE
Clone default search results

### DIFF
--- a/popup/js/search/__tests__/common.test.js
+++ b/popup/js/search/__tests__/common.test.js
@@ -295,6 +295,25 @@ describe('search', () => {
     expect(mockRenderSearchResults).toHaveBeenCalledWith()
   })
 
+  test('does not mutate source bookmarks when scoring mode-prefix default entries', async () => {
+    ext.dom.searchInput.value = 'b '
+    ext.opts.enableSearchEngines = false
+    ext.opts.customSearchEngines = []
+    ext.model.bookmarks = createBookmarksTestData([
+      {
+        id: 1,
+        title: 'Default bookmark',
+        url: 'https://bookmark.test',
+      },
+    ])
+
+    await search({ key: 'b' })
+
+    expect(ext.model.searchMode).toBe('bookmarks')
+    expect(ext.model.result[0].score).toBeDefined()
+    expect(ext.model.bookmarks[0].score).toBeUndefined()
+  })
+
   test('performs taxonomy search when tag prefix detected', async () => {
     ext.dom.searchInput.value = '#TagSearch'
     ext.model.bookmarks = createBookmarksTestData([

--- a/popup/js/search/__tests__/defaultResults.test.js
+++ b/popup/js/search/__tests__/defaultResults.test.js
@@ -59,6 +59,16 @@ describe('addDefaultEntries', () => {
       ])
       expect(ext.model.result).toBe(results)
     })
+
+    test('clones history entries so downstream scoring cannot mutate source data', async () => {
+      ext.model.searchMode = 'history'
+      ext.model.history = [{ id: 1, title: 'History 1', url: 'https://one.test' }]
+
+      const results = await addDefaultEntries()
+
+      expect(results[0]).toEqual(ext.model.history[0])
+      expect(results[0]).not.toBe(ext.model.history[0])
+    })
   })
 
   describe('tabs mode', () => {
@@ -94,6 +104,16 @@ describe('addDefaultEntries', () => {
         { id: 2, title: 'Bookmark 2' },
       ])
     })
+
+    test('clones bookmark entries so downstream scoring cannot mutate source data', async () => {
+      ext.model.searchMode = 'bookmarks'
+      ext.model.bookmarks = [{ id: 1, title: 'Bookmark 1' }]
+
+      const results = await addDefaultEntries()
+
+      expect(results[0]).toEqual(ext.model.bookmarks[0])
+      expect(results[0]).not.toBe(ext.model.bookmarks[0])
+    })
   })
 
   describe('all mode (default)', () => {
@@ -108,6 +128,7 @@ describe('addDefaultEntries', () => {
       const results = await addDefaultEntries()
 
       expect(results).toEqual([expect.objectContaining({ id: 1, title: 'Example' })])
+      expect(results[0]).not.toBe(ext.model.bookmarks[0])
     })
 
     test('adds quick bookmark action first for an unbookmarked active tab', async () => {

--- a/popup/js/search/defaultResults.js
+++ b/popup/js/search/defaultResults.js
@@ -49,7 +49,7 @@ export async function addDefaultEntries() {
 
   if (ext.model.searchMode === 'history' && ext.model.history) {
     // Display recent history by default
-    results = ext.model.history
+    results = ext.model.history.map((el) => ({ ...el }))
   } else if (ext.model.searchMode === 'tabs' && ext.model.tabs) {
     // Display last opened tabs by default
     results = ext.model.tabs
@@ -59,7 +59,7 @@ export async function addDefaultEntries() {
       })
   } else if (ext.model.searchMode === 'bookmarks' && ext.model.bookmarks) {
     // Display all bookmarks by default
-    results = ext.model.bookmarks
+    results = ext.model.bookmarks.map((el) => ({ ...el }))
   } else {
     // Default: Find bookmarks that match current page URL
     let activeTab
@@ -70,7 +70,7 @@ export async function addDefaultEntries() {
         const currentUrl = cleanUpUrl(tab.url)
         const matchingBookmarks = ext.model.bookmarks.filter((el) => el.url === currentUrl)
         if (matchingBookmarks.length > 0) {
-          results.push(...matchingBookmarks)
+          results.push(...matchingBookmarks.map((el) => ({ ...el })))
         } else if (isQuickBookmarkEnabled() && isBookmarkableUrl(tab.url)) {
           results.push(createQuickBookmarkEntry(tab))
         }


### PR DESCRIPTION
## Summary
- Clones history and bookmark entries before using them as default results.
- Prevents later scoring/render mutations from leaking back into the source search data.
- Covers history, bookmark, and current-tab bookmark defaults.

## Checks
- npm run test:unit -- popup/js/search/__tests__/defaultResults.test.js