### PR TITLE
Use scorer search term argument

### DIFF
--- a/popup/js/search/__tests__/scoring.test.js
+++ b/popup/js/search/__tests__/scoring.test.js
@@ -144,6 +144,30 @@ describe('scoring', () => {
     expect(scoreByType.direct).toBeCloseTo(500)
   })
 
+  it('uses the searchTerm argument rather than global model state for search bonuses', () => {
+    createTestExt({
+      model: { searchTerm: '' },
+      opts: {
+        ...baseOpts,
+        scoreBookmarkBase: 100,
+        scoreExactEqualsBonus: 20,
+      },
+    })
+
+    const [scored] = calculateFinalScore(
+      [
+        {
+          ...baseResult,
+          title: 'Exact Match',
+          titleLower: 'exact match',
+        },
+      ],
+      'exact match',
+    )
+
+    expect(scored.score).toBe(120)
+  })
+
   it('throws on unsupported result type', () => {
     createTestExt({
       model: { searchTerm: 'test' },

--- a/popup/js/search/scoring.js
+++ b/popup/js/search/scoring.js
@@ -16,7 +16,7 @@ const NUMERIC_TERM_REGEX = /^\d+$/
  * @returns {Array} Results with calculated scores
  */
 export function calculateFinalScore(results, searchTerm) {
-  const hasSearchTerm = Boolean(ext.model.searchTerm)
+  const hasSearchTerm = Boolean(searchTerm)
 
   // searchTerm is already lowercased from normalizeSearchTerm() in common.js
   const normalizedSearchTerm = hasSearchTerm ? searchTerm.trim() : ''


### PR DESCRIPTION
## Summary
- Uses the calculateFinalScore searchTerm argument instead of global model state.
- Keeps scoring deterministic when callers pass a search term while ext.model.searchTerm is stale or empty.
- Adds a regression test for exact-match bonuses.

## Checks
- npm run test:unit -- popup/js/search/__tests__/scoring.test.js