### PR TITLE
Require exact taxonomy matches

### DIFF
--- a/popup/js/search/__tests__/common.test.js
+++ b/popup/js/search/__tests__/common.test.js
@@ -300,7 +300,7 @@ describe('search', () => {
     ext.model.bookmarks = createBookmarksTestData([
       {
         id: 1,
-        title: 'Tagged result #tagsearch#other',
+        title: 'Tagged result #tagsearch #other',
         url: 'https://tag.test',
       },
     ])

--- a/popup/js/search/__tests__/taxonomySearch.test.js
+++ b/popup/js/search/__tests__/taxonomySearch.test.js
@@ -107,6 +107,27 @@ describe('taxonomy search', () => {
     expect(result[0].originalId).toBe('2')
   })
 
+  test('searchTaxonomy requires exact group names instead of substring matches', () => {
+    const { searchTaxonomy } = taxonomyModule
+    const data = [
+      {
+        originalId: '1',
+        group: '@Workspace',
+        groupLower: '@workspace',
+      },
+      {
+        originalId: '2',
+        group: '@Work',
+        groupLower: '@work',
+      },
+    ]
+
+    const result = searchTaxonomy('work', 'group', data)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].originalId).toBe('2')
+  })
+
   test('getUniqueTags aggregates tag usage', () => {
     const { getUniqueTags } = taxonomyModule
     ext.model.bookmarks = [

--- a/popup/js/search/__tests__/taxonomySearch.test.js
+++ b/popup/js/search/__tests__/taxonomySearch.test.js
@@ -44,6 +44,29 @@ describe('taxonomy search', () => {
     })
   })
 
+  test('searchTaxonomy requires exact tag names instead of substring matches', () => {
+    const { searchTaxonomy } = taxonomyModule
+    const data = [
+      {
+        originalId: '1',
+        tags: '#javascript',
+        tagsArrayLower: ['javascript'],
+        type: 'bookmark',
+      },
+      {
+        originalId: '2',
+        tags: '#java',
+        tagsArrayLower: ['java'],
+        type: 'bookmark',
+      },
+    ]
+
+    const result = searchTaxonomy('java', 'tags', data)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].originalId).toBe('2')
+  })
+
   test('searchTaxonomy finds entries based on folder names', () => {
     const { searchTaxonomy } = taxonomyModule
     const data = [
@@ -61,6 +84,27 @@ describe('taxonomy search', () => {
 
     expect(result).toHaveLength(1)
     expect(result[0].originalId).toBe('3')
+  })
+
+  test('searchTaxonomy requires exact folder names instead of substring matches', () => {
+    const { searchTaxonomy } = taxonomyModule
+    const data = [
+      {
+        originalId: '1',
+        folder: '~Projects Archive',
+        folderArrayLower: ['projects archive'],
+      },
+      {
+        originalId: '2',
+        folder: '~Projects',
+        folderArrayLower: ['projects'],
+      },
+    ]
+
+    const result = searchTaxonomy('projects', 'folder', data)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].originalId).toBe('2')
   })
 
   test('getUniqueTags aggregates tag usage', () => {

--- a/popup/js/search/taxonomySearch.js
+++ b/popup/js/search/taxonomySearch.js
@@ -61,17 +61,9 @@ export function searchTaxonomy(searchTerm, taxonomyType, data) {
         }
       }
 
-      // Prepare search string for taxonomy matching
-      let searchString = ''
-      if (taxonomyType === 'group') {
-        // For groups, we prepend @. Use pre-calculated groupLower if available.
-        searchString = entry.groupLower ? `@${entry.groupLower}` : entry.group ? `@${entry.group}`.toLowerCase() : ''
-      } else {
-        // For tags/folders, use pre-calculated lower field (tagsLower, folderLower)
-        searchString = entry[`${taxonomyType}Lower`] || (entry[taxonomyType] || '').toLowerCase()
-      }
+      const taxonomyValues = getTaxonomyValues(entry, taxonomyType, taxonomyMarker)
 
-      if (searchTerms.every((term) => searchString.includes(taxonomyMarker + term))) {
+      if (searchTerms.every((term) => taxonomyValues.includes(term))) {
         results.push({
           ...entry,
           searchApproach: 'taxonomy',
@@ -81,6 +73,24 @@ export function searchTaxonomy(searchTerm, taxonomyType, data) {
   }
 
   return results
+}
+
+function getTaxonomyValues(entry, taxonomyType, taxonomyMarker) {
+  if (taxonomyType === 'group') {
+    const group = entry.groupLower || (entry.group ? String(entry.group).toLowerCase() : '')
+    return group ? [String(group).replace(/^@/, '')] : []
+  }
+
+  const arrayField = taxonomyType === 'tags' ? 'tagsArrayLower' : 'folderArrayLower'
+  if (Array.isArray(entry[arrayField])) {
+    return entry[arrayField].map((value) => String(value))
+  }
+
+  const rawValue = entry[`${taxonomyType}Lower`] || entry[taxonomyType] || ''
+  return String(rawValue)
+    .split(taxonomyMarker)
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean)
 }
 
 /**

--- a/popup/js/search/taxonomySearch.js
+++ b/popup/js/search/taxonomySearch.js
@@ -1,9 +1,9 @@
 /**
- * @file Implements dedicated tag (`#`) and folder (`~`) taxonomy searches.
+ * @file Implements dedicated tag (`#`), folder (`~`), and tab group (`@`) taxonomy searches.
  *
  * Strategy:
- * - Provide AND-based filtering so queries like `#react #node` or `~Projects ~React` match bookmarks with every term.
- * - Power the tags and folders overview pages with aggregated counts derived from bookmark metadata.
+ * - Provide AND-based filtering so queries like `#react #node`, `~Projects ~React`, or `@Work` match every term.
+ * - Power taxonomy overview pages with aggregated counts derived from bookmark and tab metadata.
  * - Maintain cached taxonomy indexes for quick lookups when switching between popup navigation modes.
  *
  * Scoring:
@@ -12,12 +12,12 @@
  */
 
 /**
- * Simple, precise search for bookmark tags and folder names
+ * Simple, precise search for bookmark tags, folder names, and tab groups.
  * Executes AND search with the terms in searchTerm, separated by spaces
  *
  * @param {string} searchTerm
- * @param {'tags' | 'folder'} taxonomyType
- * @param {Array<Object>} data - Bookmark-derived taxonomy entries.
+ * @param {'tags' | 'folder' | 'group'} taxonomyType
+ * @param {Array<Object>} data - Bookmark- or tab-derived taxonomy entries.
  * @returns {Array<Object>} Taxonomy results with score metadata.
  */
 export function searchTaxonomy(searchTerm, taxonomyType, data) {


### PR DESCRIPTION
## Summary
- Changes taxonomy searches to compare parsed tag and folder values instead of substring matching.
- Prevents searches like java from matching javascript and projects from matching projects archive.
- Keeps the shared taxonomy-search path covered by tests.

## Checks
- npm run test:unit -- popup/js/search/__tests__/taxonomySearch.test.js popup/js/search/__tests__/common.test.js