### PR TITLE
Clear tab state after closing result

### DIFF
--- a/popup/js/view/__tests__/searchEvents.test.js
+++ b/popup/js/view/__tests__/searchEvents.test.js
@@ -37,13 +37,15 @@ function createResults() {
   ]
 }
 
-async function setupSearchEvents({ results = createResults(), opts = {} } = {}) {
+async function setupSearchEvents({ results = createResults(), bookmarks = [], opts = {} } = {}) {
   jest.resetModules()
   window.location.hash = '#search/query'
 
   const getUserOptions = jest.fn(async () => ({ searchStrategy: 'precise' }))
   const setUserOptions = jest.fn(async () => {})
   const searchMock = jest.fn(() => Promise.resolve())
+  const resetFuzzySearchState = jest.fn()
+  const resetSimpleSearchState = jest.fn()
 
   jest.unstable_mockModule('../../model/optionsStorage.js', () => ({
     getUserOptions,
@@ -51,6 +53,12 @@ async function setupSearchEvents({ results = createResults(), opts = {} } = {}) 
   }))
   jest.unstable_mockModule('../../search/common.js', () => ({
     search: searchMock,
+  }))
+  jest.unstable_mockModule('../../search/fuzzySearch.js', () => ({
+    resetFuzzySearchState,
+  }))
+  jest.unstable_mockModule('../../search/simpleSearch.js', () => ({
+    resetSimpleSearchState,
   }))
 
   // Import modules needed for events
@@ -75,8 +83,15 @@ async function setupSearchEvents({ results = createResults(), opts = {} } = {}) 
       originalId: entry.originalId,
       originalUrl: entry.originalUrl,
       url: entry.url,
+      title: entry.title,
+      active: entry.active,
+      favIconUrl: entry.favIconUrl,
+      group: entry.group,
+      groupLower: entry.groupLower,
+      groupId: entry.groupId,
       windowId: 101,
     }))
+  const copiedBookmarks = bookmarks.map((entry) => ({ ...entry }))
 
   navigator.clipboard = {
     writeText: jest.fn(() => Promise.resolve()),
@@ -96,6 +111,7 @@ async function setupSearchEvents({ results = createResults(), opts = {} } = {}) 
     model: {
       result: copiedResults,
       tabs: tabEntries,
+      bookmarks: copiedBookmarks,
       searchTerm: 'query',
       mouseMoved: false,
       currentItem: 0,
@@ -135,6 +151,8 @@ async function setupSearchEvents({ results = createResults(), opts = {} } = {}) 
       getUserOptions,
       setUserOptions,
       search: searchMock,
+      resetFuzzySearchState,
+      resetSimpleSearchState,
     },
     elements: {
       resultList,
@@ -231,7 +249,7 @@ describe('searchEvents openResultItem', () => {
   })
 
   it('closes tabs from the result list when the close button is pressed', async () => {
-    const { viewModule, elements } = await setupSearchEvents()
+    const { viewModule, elements, mocks } = await setupSearchEvents()
     await viewModule.renderSearchResults()
     const tabItem = elements.resultList.children[1]
     const closeButton = tabItem.querySelector('.close')
@@ -242,6 +260,88 @@ describe('searchEvents openResultItem', () => {
     expect(ext.model.tabs).toHaveLength(0)
     expect(ext.model.result).toHaveLength(1)
     expect(elements.resultList.children).toHaveLength(1)
+    expect(mocks.resetSimpleSearchState).toHaveBeenCalledWith('tabs')
+    expect(mocks.resetFuzzySearchState).toHaveBeenCalledWith('tabs')
+  })
+
+  it('clears open-tab metadata from matching bookmarks when a tab is closed', async () => {
+    const results = createResults()
+    results[1].active = true
+    results[1].favIconUrl = 'https://tab.test/favicon.png'
+    results[1].group = 'Work'
+    results[1].groupLower = 'work'
+    results[1].groupId = 7
+
+    const bookmarks = [
+      {
+        type: 'bookmark',
+        originalId: 'bm-open',
+        originalUrl: 'https://tab.test',
+        url: 'tab.test',
+        title: 'Bookmarked Tab',
+        tab: true,
+        openTabTitle: 'Tab Title',
+        openTabActive: true,
+        favIconUrl: 'https://tab.test/favicon.png',
+        group: 'Work',
+        groupLower: 'work',
+        groupId: 7,
+      },
+      {
+        type: 'bookmark',
+        originalId: 'bm-other',
+        originalUrl: 'https://other.test',
+        url: 'other.test',
+        title: 'Other Bookmark',
+        tab: true,
+        openTabTitle: 'Other Tab',
+      },
+    ]
+
+    const { viewModule, elements } = await setupSearchEvents({ results, bookmarks })
+    await viewModule.renderSearchResults()
+
+    elements.resultList.children[1].querySelector('.close').dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+
+    expect(ext.model.bookmarks[0]).toMatchObject({
+      type: 'bookmark',
+      originalId: 'bm-open',
+      originalUrl: 'https://tab.test',
+      url: 'tab.test',
+      title: 'Bookmarked Tab',
+    })
+    expect(ext.model.bookmarks[0].tab).toBeUndefined()
+    expect(ext.model.bookmarks[0].openTabTitle).toBeUndefined()
+    expect(ext.model.bookmarks[0].openTabActive).toBeUndefined()
+    expect(ext.model.bookmarks[0].favIconUrl).toBeUndefined()
+    expect(ext.model.bookmarks[0].group).toBeUndefined()
+    expect(ext.model.bookmarks[0].groupLower).toBeUndefined()
+    expect(ext.model.bookmarks[0].groupId).toBeUndefined()
+    expect(ext.model.bookmarks[1].tab).toBe(true)
+    expect(ext.model.bookmarks[1].openTabTitle).toBe('Other Tab')
+  })
+
+  it('ignores stale close buttons without a valid tab id', async () => {
+    const { module } = await setupSearchEvents()
+
+    module.openResultItem({
+      button: 0,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      target: {
+        nodeName: 'BUTTON',
+        className: 'close',
+        parentElement: null,
+        getAttribute: () => null,
+      },
+      stopPropagation: jest.fn(),
+      preventDefault: jest.fn(),
+    })
+
+    expect(ext.browserApi.tabs.remove).not.toHaveBeenCalled()
+    expect(ext.model.tabs).toHaveLength(1)
+    expect(ext.model.result).toHaveLength(2)
   })
 
   it('does not delete wrong tab when originalId is not found in model (BUG: findIndex returns -1)', async () => {

--- a/popup/js/view/searchEvents.js
+++ b/popup/js/view/searchEvents.js
@@ -12,6 +12,8 @@
 import { cleanUpUrl } from '../helper/utils.js'
 import { getUserOptions, setUserOptions } from '../model/optionsStorage.js'
 import { search } from '../search/common.js'
+import { resetFuzzySearchState } from '../search/fuzzySearch.js'
+import { resetSimpleSearchState } from '../search/simpleSearch.js'
 import { clearSelection, hoverResultItem } from './searchNavigation.js'
 import { renderSearchResults } from './searchView.js'
 
@@ -19,6 +21,30 @@ import { renderSearchResults } from './searchView.js'
 // Using a module variable instead of a DOM property ensures the state
 // survives any potential DOM replacement and prevents duplicate event listeners.
 let eventDelegationSetup = false
+
+function clearBookmarkOpenTabState(closedTab) {
+  if (!closedTab?.url || !Array.isArray(ext.model.bookmarks)) {
+    return
+  }
+
+  for (const bookmark of ext.model.bookmarks) {
+    if (bookmark?.url !== closedTab.url) {
+      continue
+    }
+
+    delete bookmark.tab
+    delete bookmark.openTabTitle
+    delete bookmark.openTabActive
+
+    if (bookmark.favIconUrl === closedTab.favIconUrl) {
+      delete bookmark.favIconUrl
+    }
+
+    delete bookmark.group
+    delete bookmark.groupLower
+    delete bookmark.groupId
+  }
+}
 
 /**
  * Handle click/mouse events on search results with different behaviors based on modifiers and target elements
@@ -55,9 +81,18 @@ export function openResultItem(event) {
 
       const originalIdFromDom = listItem?.getAttribute('x-original-id')
       const targetId = parseInt(originalIdFromDom, 10)
+      if (!Number.isInteger(targetId)) {
+        return
+      }
 
       // Close the browser tab
-      ext.browserApi.tabs.remove(targetId)
+      try {
+        Promise.resolve(ext.browserApi.tabs.remove(targetId)).catch((err) => {
+          console.warn('Could not close tab:', err)
+        })
+      } catch (err) {
+        console.warn('Could not close tab:', err)
+      }
 
       // Remove the item from the UI - use targetId to ensure we have a valid value
       const domElement = document.querySelector(`#results > li[x-original-id="${targetId}"]`)
@@ -68,7 +103,9 @@ export function openResultItem(event) {
       // Update the application state - only remove if found (findIndex returns -1 if not found)
       const tabIndex = ext.model.tabs.findIndex((el) => el.originalId === targetId)
       if (tabIndex !== -1) {
+        const closedTab = ext.model.tabs[tabIndex]
         ext.model.tabs.splice(tabIndex, 1)
+        clearBookmarkOpenTabState(closedTab)
       }
 
       const resultIndex = ext.model.result.findIndex((el) => el.originalId === targetId)
@@ -80,6 +117,8 @@ export function openResultItem(event) {
       if (ext.searchCache) {
         ext.searchCache.clear()
       }
+      resetSimpleSearchState('tabs')
+      resetFuzzySearchState('tabs')
 
       // Re-render to update indices and selection
       renderSearchResults()


### PR DESCRIPTION
## Summary
- Ignores stale close buttons without a valid tab id.
- Logs tab-close API failures without breaking local UI cleanup.
- Clears matching bookmark open-tab metadata and resets search caches after closing a tab result.

## Checks
- npm run test:unit -- popup/js/view/__tests__/searchEvents.test.js