### PR TITLE
Clear fuzzy results after search failure

### DIFF
--- a/popup/js/search/__tests__/fuzzySearch.test.js
+++ b/popup/js/search/__tests__/fuzzySearch.test.js
@@ -394,6 +394,36 @@ describe('fuzzySearch', () => {
     expect(results.length).toBeGreaterThanOrEqual(0)
   })
 
+  it('returns no partial results when uFuzzy fails on a later search term', async () => {
+    class ThrowingUFuzzy {
+      filter(_haystack, term) {
+        if (term === 'alpha') return [0, 1]
+        throw new Error('filter failed')
+      }
+    }
+
+    window.uFuzzy = ThrowingUFuzzy
+    globalThis.uFuzzy = ThrowingUFuzzy
+    resetFuzzySearchState()
+
+    model.bookmarks = createBookmarksTestData([
+      {
+        id: 'bookmark-1',
+        title: 'Alpha beta',
+        url: 'https://example.com/alpha-beta',
+      },
+      {
+        id: 'bookmark-2',
+        title: 'Alpha only',
+        url: 'https://example.com/alpha',
+      },
+    ])
+
+    const results = await fuzzySearch('bookmarks', 'alpha beta', model, opts)
+
+    expect(results).toEqual([])
+  })
+
   it('handles empty search terms gracefully', async () => {
     model.bookmarks = createBookmarksTestData([
       {

--- a/popup/js/search/fuzzySearch.js
+++ b/popup/js/search/fuzzySearch.js
@@ -142,6 +142,8 @@ function fuzzySearchWithScoring(searchTerm, searchMode, data, opts) {
     } catch (err) {
       err.message = 'Fuzzy search could not handle search term. Please try precise search instead.'
       printError(err)
+      s.idxs = []
+      break
     }
 
     if (!s.idxs?.length) {


### PR DESCRIPTION
## Summary
- Clears cached fuzzy indices when uFuzzy fails on a later search term.
- Stops returning partial results from earlier terms after an error.
- Adds a regression test for the multi-term failure path.

## Checks
- npm run test:unit -- popup/js/search/__tests__/fuzzySearch.test.js