### PR TITLE
Guard missing bookmark updates

### DIFF
--- a/popup/js/view/__tests__/editBookmarkView.test.js
+++ b/popup/js/view/__tests__/editBookmarkView.test.js
@@ -414,6 +414,25 @@ describe('editBookmarkView', () => {
     expect(bookmark.customBonusScore).toBe(0)
   })
 
+  it('does not throw when updating a bookmark that is no longer in the model', async () => {
+    setupDom()
+    setupExt([])
+    const { module, mocks } = await loadEditBookmarkView()
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(() => module.updateBookmark(BOOKMARK_ID)).not.toThrow()
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Tried to update bookmark id="${BOOKMARK_ID}", but could not find it in searchData.`,
+    )
+    expect(mocks.browserApi.bookmarks.update).not.toHaveBeenCalled()
+    expect(mocks.resetFuzzySearchState).not.toHaveBeenCalled()
+    expect(mocks.resetSimpleSearchState).not.toHaveBeenCalled()
+    expect(mocks.resetUniqueFoldersCache).not.toHaveBeenCalled()
+
+    warnSpy.mockRestore()
+  })
+
   it('preserves a custom bonus score when the favorite button was not cycled', async () => {
     setupDom()
     const bookmark = {

--- a/popup/js/view/editBookmarkView.js
+++ b/popup/js/view/editBookmarkView.js
@@ -207,6 +207,11 @@ function setupTagEditor(tagsInput, currentTags) {
  */
 export function updateBookmark(bookmarkId) {
   const bookmark = ext.model.bookmarks.find((el) => el.originalId === bookmarkId)
+  if (!bookmark) {
+    console.warn(`Tried to update bookmark id="${bookmarkId}", but could not find it in searchData.`)
+    return
+  }
+
   const formValues = getBookmarkFormValues()
 
   // Update search data model of bookmark


### PR DESCRIPTION
## Summary
- Handles update requests for bookmarks that are no longer present in the model.
- Warns and returns before mutating state, resetting caches, or calling the browser bookmarks API.
- Adds a regression test for the missing-model path.

## Checks
- npm run test:unit -- popup/js/view/__tests__/editBookmarkView.test.js