### PR TITLE
Remove stale error overlay key listener

### DIFF
--- a/popup/js/view/__tests__/errorView.test.js
+++ b/popup/js/view/__tests__/errorView.test.js
@@ -91,6 +91,22 @@ describe('printError with overlay', () => {
     expect(overlay.innerHTML).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
     expect(overlay.innerHTML).toContain('&lt;b&gt;bad markup&lt;/b&gt;')
   })
+
+  it('removes the Escape listener when the overlay is dismissed by button', () => {
+    const addSpy = jest.spyOn(document, 'addEventListener')
+    const removeSpy = jest.spyOn(document, 'removeEventListener')
+
+    printError(new Error('Dismiss me'))
+    const keydownHandler = addSpy.mock.calls.find(([eventName]) => eventName === 'keydown')?.[1]
+
+    document.getElementById('btn-dismiss-error').click()
+
+    expect(keydownHandler).toBeDefined()
+    expect(removeSpy).toHaveBeenCalledWith('keydown', keydownHandler)
+
+    addSpy.mockRestore()
+    removeSpy.mockRestore()
+  })
 })
 
 describe('printError no DOM element', () => {

--- a/popup/js/view/errorView.js
+++ b/popup/js/view/errorView.js
@@ -11,6 +11,7 @@ import { escapeHtml } from '../helper/utils.js'
 
 /** Track accumulated errors for display */
 let errorQueue = []
+let escHandler
 
 /**
  * Hide the global error overlay if present on the current page.
@@ -25,6 +26,11 @@ export function closeErrors() {
 
   // Clear the error queue
   errorQueue = []
+
+  if (escHandler) {
+    document.removeEventListener('keydown', escHandler)
+    escHandler = undefined
+  }
 }
 
 /**
@@ -105,10 +111,12 @@ function renderErrorOverlay(overlay, errors) {
   }
 
   // Also close on Escape key
-  const escHandler = (e) => {
+  if (escHandler) {
+    document.removeEventListener('keydown', escHandler)
+  }
+  escHandler = (e) => {
     if (e.key === 'Escape') {
       closeErrors()
-      document.removeEventListener('keydown', escHandler)
     }
   }
   document.addEventListener('keydown', escHandler)


### PR DESCRIPTION
## Summary
- Tracks the active Escape-key error overlay listener at module scope.
- Removes the listener when errors are dismissed by button or by Escape.
- Adds a regression test for button dismissal cleanup.

## Checks
- npm run test:unit -- popup/js/view/__tests__/errorView.test.js