### PR TITLE
Tighten performance test workflow

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Update Popup Libraries
+        run: npm run build:update-libs
+
       - name: Get Playwright version
         id: playwright-version
         run: echo "version=$(npm ls @playwright/test --json | jq -r '.dependencies["@playwright/test"].version')" >> $GITHUB_OUTPUT

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test:unit": "node --experimental-vm-modules --disable-warning=ExperimentalWarning ./node_modules/jest/bin/jest.js",
     "test:unit:watch": "node --experimental-vm-modules --disable-warning=ExperimentalWarning ./node_modules/jest/bin/jest.js --watch",
     "test:unit:coverage": "node --experimental-vm-modules --disable-warning=ExperimentalWarning ./node_modules/jest/bin/jest.js --coverage",
-    "test:perf": "npm run test:unit -- popup/js/__tests__/performance.test.js popup/js/__tests__/comparison.test.js > reports/jest_output.txt 2>&1 && npx playwright test playwright/tests/performance.spec.js --project=chromium > reports/playwright_output.txt 2>&1; node bin/perf-summary.js",
+    "test:perf": "npm run test:unit -- popup/js/__tests__/performance.test.js popup/js/__tests__/comparison.test.js > reports/jest_output.txt 2>&1 && npx playwright test playwright/tests/performance.spec.js --project=chromium > reports/playwright_output.txt 2>&1 && node bin/perf-summary.js",
     "test:ci": "npm run lint && npm run test:unit && npm run test:e2e",
     "lint": "biome check --error-on-warnings .",
     "lint:fix": "biome check --write .",


### PR DESCRIPTION
## Summary
- Runs popup library updates before the performance workflow uses the bundled popup libraries.
- Makes npm run test:perf fail when the Playwright perf command fails instead of always continuing to the summary.
- Leaves stale dependency bumps from PR 348 out because main already has newer versions.

## Checks
- npm run lint
- npm run test:perf