### PR TITLE
Release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## [Unreleased]
 
+## [v2.4.0] - 2026-06-22
+
 - **NEW**: Moved user options into the full-page Bookmark Manager as a dedicated Options tab.
-  - Adds a schema-driven form with explicit per-option opt-in controls, inline descriptions, live validation, and a synced YAML editor.
-  - The browser extension options entry and popup navigation now open `popup/bookmarkManager.html#options` in a full tab.
-- **NEW**: Added `F2` in the search popup to edit the selected bookmark, or create a new bookmark from the selected URL.
-- **FIXED**: Allowed an empty `quickBookmarkCurrentTab` value in the Options editor and documented how to disable the quick-bookmark default result.
+- **NEW**: Use `F2` in the search popup to edit the selected bookmark, or create a new bookmark from the selected URL.
+- **NEW**: Added a Quick Bookmark default result for saving the current tab through the rich bookmark editor.
+  - Configure its target folder with `quickBookmarkCurrentTab`, or set that option to an empty string to disable it.
+- **NEW**: Added `openInCurrentTab` to open selected results in the current tab by default, with `Shift` or `Alt` inverting that behavior.
+- **FIXED**: Closing a tab result now clears matching bookmark open-tab state and related cached results.
 
 ## [v2.3.0] - 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,20 @@
 
 ## [v2.4.0] - 2026-06-27
 
+- **NEW**: Added quick bookmark and edit actions directly from search results.
+  - The default result can now save the current tab through the rich bookmark editor.
+  - Use `F2` in the search popup to edit the selected bookmark, or create a new bookmark from the selected URL.
+  - Configure the quick-bookmark target folder with `quickBookmarkCurrentTab`, or set that option to an empty string to disable it.
 - **NEW**: Moved user options into the full-page Bookmark Manager as a dedicated Options tab.
-- **NEW**: Use `F2` in the search popup to edit the selected bookmark, or create a new bookmark from the selected URL.
-- **NEW**: Added a Quick Bookmark default result for saving the current tab through the rich bookmark editor.
-  - Configure its target folder with `quickBookmarkCurrentTab`, or set that option to an empty string to disable it.
-- **NEW**: Added `openInCurrentTab` to open selected results in the current tab by default, with `Shift` or `Alt` inverting that behavior.
-- **FIXED**: Closing a tab result now clears matching bookmark open-tab state and related cached results.
   - Adds a schema-driven form with explicit per-option opt-in controls, inline descriptions, live validation, and a synced YAML editor.
   - The browser extension options entry and popup navigation now open `popup/bookmarkManager.html#options` in a full tab.
-- **NEW**: Added `F2` in the search popup to edit the selected bookmark, or create a new bookmark from the selected URL.
+- **NEW**: Added `openInCurrentTab` to open selected results in the current tab by default, with `Shift` or `Alt` inverting that behavior.
+- **FIXED**: Search result state now refreshes more reliably after tab closes, bookmark edits, default-result actions, and fuzzy search failures.
+- **FIXED**: Opening the popup with a `#search/...` route now runs that initial search after startup.
+- **FIXED**: Invalid stored options now fall back to defaults and show the dismissible error overlay.
 - **REMOVED**: Removed the popup `detectDuplicateBookmarks` option and duplicate result badge. Duplicate cleanup remains available in the Bookmark Manager.
-- **IMPROVED**: Minor popup startup and search performance improvements, with expanded benchmark coverage for realistic data sizes and default results.
 - **REMOVED**: Dropped the `displayIcons` option and result-type placeholder icons from search results.
-- **FIXED**: Allowed an empty `quickBookmarkCurrentTab` value in the Options editor and documented how to disable the quick-bookmark default result.
+- **IMPROVED**: Minor popup startup and search performance improvements, with expanded benchmark coverage for realistic data sizes and default results.
 
 ## [v2.3.0] - 2026-05-09
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "description": "Browser extension to (fuzzy) search and navigate bookmarks, history and open tabs.",
   "homepage_url": "https://github.com/Fannon/search-bookmarks-history-and-tabs",
   "author": "Simon Heimler",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "permissions": ["tabs", "bookmarks", "history", "storage", "tabGroups"],
   "optional_permissions": ["favicon"],
   "action": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@leeoniya/ufuzzy": "^1.0.19",
-        "@yaireo/tagify": "^4.37.1",
+        "@yaireo/tagify": "^4.38.0",
         "js-yaml": "^5.2.0"
       },
       "devDependencies": {
@@ -2379,9 +2379,9 @@
       ]
     },
     "node_modules/@yaireo/tagify": {
-      "version": "4.37.1",
-      "resolved": "https://registry.npmjs.org/@yaireo/tagify/-/tagify-4.37.1.tgz",
-      "integrity": "sha512-/+0ZZ55rd4sG5Nlop2QF9D2oo3kbRgn/KlsW6oN1MwKVS7DDB2mIrGnizk740M0qzXvQfE7JhbCeWDuC8+6kmA==",
+      "version": "4.38.0",
+      "resolved": "https://registry.npmjs.org/@yaireo/tagify/-/tagify-4.38.0.tgz",
+      "integrity": "sha512-/ZyG2NWQGNcTK4ay2aPE3ka/ZQmhTo+bUKb81SqjtQlt3VrGoxCNhmvKTV/mBJbY69BOXXeBEi+a5JLrvp6wLA==",
       "license": "MIT",
       "engines": {
         "node": ">=22",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "search-bookmarks-history-and-tabs",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "search-bookmarks-history-and-tabs",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "@leeoniya/ufuzzy": "^1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "search-bookmarks-history-and-tabs",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "private": true,
   "description": "Browser extension to (fuzzy) search and navigate bookmarks, history and open tabs.",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@leeoniya/ufuzzy": "^1.0.19",
-    "@yaireo/tagify": "^4.37.1",
+    "@yaireo/tagify": "^4.38.0",
     "js-yaml": "^5.2.0"
   },
   "devDependencies": {

--- a/popup/bookmarkManager.html
+++ b/popup/bookmarkManager.html
@@ -48,6 +48,7 @@
     <div class="manager-actions">
       <button id="undo-bookmark-change" class="button secondary" type="button"
         title="Undo the latest bookmark manager change" disabled>Undo</button>
+      <button id="export-bookmarks" class="button secondary" type="button">Export Bookmarks</button>
       <button id="refresh-bookmarks" class="button" type="button" title="Refresh bookmarks">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
           stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -56,12 +57,6 @@
         </svg>
         Refresh
       </button>
-    </div>
-    <div class="bookmark-backup-note">
-      <span>
-        Backup bookmarks before bulk changes. Undo keeps 50 changes only until this page closes or reloads.
-      </span>
-      <button id="export-bookmarks" class="button secondary" type="button">Export Bookmarks</button>
     </div>
   </header>
 
@@ -143,6 +138,11 @@
                     </div>
                   </div>
 
+                  <p class="bookmark-safety-note">
+                    Export a backup before changing many bookmarks. Undo only keeps the latest 50 changes and is cleared
+                    when this page closes.
+                  </p>
+
                   <label for="bookmark-move-folder">Move to folder</label>
                   <select id="bookmark-move-folder"></select>
                   <button id="move-selected-bookmarks" class="button warning" type="button"
@@ -204,6 +204,10 @@
           <div id="duplicate-summary"></div>
         </header>
         <div class="duplicate-toolbar">
+          <p class="bookmark-safety-note">
+            Export a backup before deleting bookmarks. Undo only keeps the latest 50 changes and is cleared when this
+            page closes.
+          </p>
           <div class="duplicate-actions">
             <button id="select-suggested" class="button secondary" type="button">Select Lower-Ranked Copies</button>
             <button id="select-none" class="button secondary" type="button">Select None</button>
@@ -224,6 +228,10 @@
         <div class="tag-toolbar">
           <input id="tag-filter" type="search" placeholder="Filter tags" autocomplete="off" spellcheck="false" />
         </div>
+        <p class="bookmark-safety-note">
+          Export a backup before changing tags on many bookmarks. Undo only keeps the latest 50 changes and is cleared
+          when this page closes.
+        </p>
         <div id="tag-list"></div>
       </section>
 
@@ -306,6 +314,10 @@
             <h2>Proposed Changes</h2>
             <button id="apply-all-cleanup-changes" class="button success" type="button" disabled>Accept All</button>
           </header>
+          <p class="bookmark-safety-note">
+            Export a backup before applying cleanup changes. Undo only keeps the latest 50 changes and is cleared when
+            this page closes.
+          </p>
           <div id="cleanup-proposal-summary" class="cleanup-proposal-summary"></div>
           <div id="cleanup-proposal-list"></div>
         </section>

--- a/popup/css/bookmarkManager.css
+++ b/popup/css/bookmarkManager.css
@@ -85,18 +85,6 @@ button {
   gap: 10px 18px;
 }
 
-.manager-header .bookmark-backup-note {
-  grid-column: 1 / -1;
-  margin: 0 -22px -10px;
-  padding-inline: 22px;
-  border: none;
-  border-top: 1px solid #b38c30;
-  border-radius: 0;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  justify-content: stretch;
-}
-
 .manager-header h1 {
   color: var(--input-fg);
   font-size: 22px;
@@ -1297,25 +1285,17 @@ h3 {
   font-size: 13px;
 }
 
-.bookmark-backup-note {
-  margin: 0 0 12px;
-  padding: 8px 10px;
-  background: #fff1b8;
-  border: none;
-  border-radius: 0;
-  color: #3d2a00;
-  font-size: 14px;
-  font-weight: 600;
-  line-height: 1.4;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  flex-wrap: wrap;
-}
-
-.bookmark-backup-note span {
-  min-width: 0;
+.bookmark-safety-note {
+  margin: 4px 0;
+  padding: 7px 9px;
+  background: #fff7d6;
+  border-left: 3px solid #c99012;
+  border-radius: 4px;
+  color: #5a3b00;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.35;
+  min-height: 0;
 }
 
 .undo-toolbar {
@@ -1483,6 +1463,10 @@ h3 {
   margin-top: 16px;
 }
 
+.cleanup-review-section .bookmark-safety-note {
+  margin-bottom: 10px;
+}
+
 .cleanup-review-header {
   display: flex;
   align-items: center;
@@ -1627,6 +1611,10 @@ h3 {
   align-items: center;
   margin-bottom: 10px;
   padding: 0;
+}
+
+.duplicate-toolbar .bookmark-safety-note {
+  margin: 0 auto 0 0;
 }
 
 .duplicate-group {
@@ -2072,9 +2060,9 @@ h3 {
     background: #414141;
   }
 
-  .bookmark-backup-note {
-    background: #3a2b06;
-    border-top: 1px solid #9a6500;
+  .bookmark-safety-note {
+    background: #2f260f;
+    border-left-color: #b98213;
     color: #ffe7a3;
   }
 


### PR DESCRIPTION
## [v2.4.0] - 2026-06-27

- **NEW**: Added quick bookmark and edit actions directly from search results.
  - The default result can now save the current tab through the rich bookmark editor.
  - Use `F2` in the search popup to edit the selected bookmark, or create a new bookmark from the selected URL.
  - Configure the quick-bookmark target folder with `quickBookmarkCurrentTab`, or set that option to an empty string to disable it.
- **NEW**: Moved user options into the full-page Bookmark Manager as a dedicated Options tab.
  - Adds a schema-driven form with explicit per-option opt-in controls, inline descriptions, live validation, and a synced YAML editor.
  - The browser extension options entry and popup navigation now open `popup/bookmarkManager.html#options` in a full tab.
- **NEW**: Added `openInCurrentTab` to open selected results in the current tab by default, with `Shift` or `Alt` inverting that behavior.
- **FIXED**: Search result state now refreshes more reliably after tab closes, bookmark edits, default-result actions, and fuzzy search failures.
- **FIXED**: Opening the popup with a `#search/...` route now runs that initial search after startup.
- **FIXED**: Invalid stored options now fall back to defaults and show the dismissible error overlay.
- **REMOVED**: Removed the popup `detectDuplicateBookmarks` option and duplicate result badge. Duplicate cleanup remains available in the Bookmark Manager.
- **REMOVED**: Dropped the `displayIcons` option and result-type placeholder icons from search results.
- **IMPROVED**: Minor popup startup and search performance improvements, with expanded benchmark coverage for realistic data sizes and default results.