### PR TITLE
Remove popup duplicate bookmark badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Adds a schema-driven form with explicit per-option opt-in controls, inline descriptions, live validation, and a synced YAML editor.
   - The browser extension options entry and popup navigation now open `popup/bookmarkManager.html#options` in a full tab.
 - **NEW**: Added `F2` in the search popup to edit the selected bookmark, or create a new bookmark from the selected URL.
+- **REMOVED**: Removed the popup `detectDuplicateBookmarks` option and duplicate result badge. Duplicate cleanup remains available in the Bookmark Manager.
 - **REMOVED**: Dropped the `displayIcons` option and result-type placeholder icons from search results.
 - **FIXED**: Allowed an empty `quickBookmarkCurrentTab` value in the Options editor and documented how to disable the quick-bookmark default result.
 

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -64,7 +64,6 @@ Control what information is shown in search result items.
 | Option | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
 | `bookmarksIgnoreFolderList` | array | `[]` | List of bookmark folder paths to exclude from search. All bookmarks in these folders (and their subfolders) will be ignored. Example: `['Archive', 'Work/Old Bookmarks']` |
-| `detectDuplicateBookmarks` | boolean | `false` | Detect bookmarks with identical URLs and mark them with a red "D" badge. Useful for cleaning up duplicates. Disable for faster startup with large collections. |
 
 ## Tabs Options
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,6 @@ displaySearchMatchHighlight: false # Not highlighting search matches improves re
 searchMaxResults: 20 # Number of search results can be further limited
 historyMaxItems: 512 # Number of browser history items can be further reduced
 maxRecentTabsToShow: 4 # Reduce number of recent tabs for better performance
-detectDuplicateBookmarks: false # Disable duplicate detection for faster startup (if you don't have duplicates)
 ```
 
 Or a more advanced example:
@@ -201,7 +200,6 @@ historyIgnoreList:
   - http://localhost
   - http://127.0.0.1
 scoreTabBase: 70 # customize base score for open tabs
-detectDuplicateBookmarks: true
 maxRecentTabsToShow: 4
 searchEngineChoices:
   - name: Google

--- a/Tips.md
+++ b/Tips.md
@@ -54,7 +54,6 @@ If the extension feels slow to open or search:
 - **Custom Scores**: Boost important bookmarks by adding ` +20` (or any number) to the title.
   - *Example*: `Production Dashboard +50 #work`
 - **Exclusion Folders**: Use `bookmarksIgnoreFolderList` to completely hide archive or sensitive folders from search results.
-- **Duplicate Detection**: Enable `detectDuplicateBookmarks: true` to see a red **D** badge on redundant bookmarks.
 - **Open Tab Indicators**: A bookmark that is already open in a tab gets an open-tab score bonus and a bookmark-to-tab color stripe in search results.
 
 ---

--- a/popup/css/style.css
+++ b/popup/css/style.css
@@ -152,9 +152,6 @@ code {
   position: relative;
   top: -2px;
 }
-.badge.duplicate {
-  background: #d9534f;
-}
 .tags {
   background: var(--badge-tag);
 }

--- a/popup/js/__tests__/testUtils.js
+++ b/popup/js/__tests__/testUtils.js
@@ -92,7 +92,7 @@ export function clearTestExt() {
 function withExt(fn) {
   const originalExt = global.ext
   if (!global.ext?.opts) {
-    global.ext = { opts: { ...defaultOptions, detectDuplicateBookmarks: false } }
+    global.ext = { opts: { ...defaultOptions } }
   }
   try {
     return fn()

--- a/popup/js/helper/__tests__/browserApi.test.js
+++ b/popup/js/helper/__tests__/browserApi.test.js
@@ -301,7 +301,6 @@ describe('convertBrowserBookmarks', () => {
       ],
       folderTrail,
       3,
-      undefined,
       '',
     )
 
@@ -309,9 +308,8 @@ describe('convertBrowserBookmarks', () => {
     expect(folderTrail.map).not.toHaveBeenCalled()
   })
 
-  it('flags duplicate bookmarks when detection is enabled', () => {
+  it('preserves duplicate bookmark URLs without popup duplicate flags', () => {
     ext.opts.bookmarksIgnoreFolderList = []
-    ext.opts.detectDuplicateBookmarks = true
     const tree = [
       {
         title: 'Root',
@@ -330,56 +328,11 @@ describe('convertBrowserBookmarks', () => {
       },
     ]
 
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const result = convertBrowserBookmarks(tree)
 
-    try {
-      const result = convertBrowserBookmarks(tree)
-
-      const duplicates = result.filter((bookmark) => bookmark.dupe)
-      expect(duplicates).toHaveLength(2)
-      expect(duplicates.every((bookmark) => bookmark.dupe)).toBe(true)
-      expect(warnSpy).toHaveBeenCalledTimes(1)
-      expect(warnSpy.mock.calls[0][0]).toContain('Duplicate bookmark detected')
-      expect(warnSpy.mock.calls[0][0]).toContain('https://duplicate.example.com')
-      expect(warnSpy.mock.calls[0][0]).toContain('folder: /')
-    } finally {
-      warnSpy.mockRestore()
-    }
-  })
-
-  it('skips duplicate detection when disabled', () => {
-    ext.opts.bookmarksIgnoreFolderList = []
-    ext.opts.detectDuplicateBookmarks = false
-    const tree = [
-      {
-        title: 'Root',
-        children: [
-          {
-            id: 'bookmark-1',
-            title: 'First entry',
-            url: 'https://duplicate.example.com',
-          },
-          {
-            id: 'bookmark-2',
-            title: 'Second entry',
-            url: 'https://duplicate.example.com',
-          },
-        ],
-      },
-    ]
-
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
-
-    try {
-      const result = convertBrowserBookmarks(tree)
-
-      // When detection is disabled, dupe flag should not be set
-      const duplicates = result.filter((bookmark) => bookmark.dupe)
-      expect(duplicates).toHaveLength(0)
-      expect(warnSpy).not.toHaveBeenCalled()
-    } finally {
-      warnSpy.mockRestore()
-    }
+    expect(result).toHaveLength(2)
+    expect(result.map((bookmark) => bookmark.url)).toEqual(['duplicate.example.com', 'duplicate.example.com'])
+    expect(result.some((bookmark) => bookmark.dupe)).toBe(false)
   })
 })
 

--- a/popup/js/helper/browserApi.js
+++ b/popup/js/helper/browserApi.js
@@ -9,7 +9,7 @@ const REGEX_SPECIAL_CHARS_REGEX = /[.*+?^${}()|[\]/-]/g
  * - Fetch raw entries with defensive fallbacks for browsers that omit certain APIs.
  * - Convert every record into the shared `searchItem` shape (type, title, url, tags, folder trail, search strings).
  * - Parse inline annotations like `#tag` taxonomy markers and `+20` custom bonus hints from bookmark titles.
- * - Preserve source URLs exactly while also deriving normalized URL keys for search, comparisons, and dedupe.
+ * - Preserve source URLs exactly while also deriving normalized URL keys for search and comparisons.
  * - Preserve breadcrumb-style folder metadata so taxonomy pages and scoring rules stay in sync across browsers.
  */
 
@@ -142,7 +142,6 @@ export async function getBrowserBookmarks() {
  * @param {Array<Object>} bookmarks - Raw bookmark tree nodes.
  * @param {Array<string>} [folderTrail] - Accumulated folder hierarchy.
  * @param {number} [depth] - Current traversal depth.
- * @param {Map<string, Object>} [seenByUrl] - Map to track duplicate URLs (only if duplicate detection is enabled).
  * @param {string} [folderText] - Pre-calculated folder string for search.
  * @returns {Array<Object>} Flattened bookmark entries.
  */
@@ -150,7 +149,6 @@ export function convertBrowserBookmarks(
   bookmarks,
   folderTrail = [],
   depth = 1,
-  seenByUrl,
   folderText,
   result = [],
   folderLower = '',
@@ -166,11 +164,6 @@ export function convertBrowserBookmarks(
     folderText = ''
     folderLower = ''
     folderArrayLower = []
-  }
-
-  // Only initialize seenByUrl Map if duplicate detection is enabled
-  if (seenByUrl === undefined && ext.opts.detectDuplicateBookmarks) {
-    seenByUrl = new Map()
   }
 
   const ignoreList = ext.opts.bookmarksIgnoreFolderList
@@ -251,20 +244,6 @@ export function convertBrowserBookmarks(
         }
       }
 
-      // Only detect duplicates if the feature is enabled
-      if (seenByUrl) {
-        const existingEntry = seenByUrl.get(mappedEntry.url)
-        if (existingEntry) {
-          existingEntry.dupe = true
-          mappedEntry.dupe = true
-          console.warn(
-            `Duplicate bookmark detected for ${mappedEntry.originalUrl} in folder: ${mappedEntry.folderArray.join(' > ') || '/'}`,
-          )
-        } else {
-          seenByUrl.set(mappedEntry.url, mappedEntry)
-        }
-      }
-
       result.push(mappedEntry)
     } else if (entry.children) {
       // It's a folder
@@ -297,7 +276,6 @@ export function convertBrowserBookmarks(
         entry.children,
         newFolderTrail,
         depth + 1,
-        seenByUrl,
         nextFolderText,
         result,
         nextFolderLower,

--- a/popup/js/initBookmarkManager.js
+++ b/popup/js/initBookmarkManager.js
@@ -107,7 +107,6 @@ export async function initBookmarkManager() {
   ext.opts.enableTabs = true
   ext.opts.enableHistory = false
   ext.opts.enableBookmarks = true
-  ext.opts.detectDuplicateBookmarks = false
   ext.opts.bookmarksIgnoreFolderList = []
   applyManagerColors()
 

--- a/popup/js/model/optionsDefaults.js
+++ b/popup/js/model/optionsDefaults.js
@@ -95,8 +95,6 @@ export const defaultOptions = {
 
   /** Bookmark folder paths to exclude from indexing */
   bookmarksIgnoreFolderList: [],
-  /** Detect and mark duplicate bookmarks (same URL) */
-  detectDuplicateBookmarks: false,
 
   //////////////////////////////////////////
   // TABS OPTIONS                         //

--- a/popup/js/view/searchView.js
+++ b/popup/js/view/searchView.js
@@ -16,8 +16,6 @@ import { selectListItem } from './searchNavigation.js'
 const createBadge = (content, title, extraClass = '', extraLink = '', extraStyle = '') =>
   `<span class="badge ${extraClass}"${title ? ` title="${escapeHtml(title)}"` : ''}${extraLink ? ` x-link="${escapeHtml(extraLink)}"` : ''}${extraStyle ? ` style="${extraStyle}"` : ''}>${content}</span>`
 
-const BADGE_DUPLICATE = createBadge('Duplicate', 'Duplicate Bookmark', 'duplicate')
-
 const TYPE_LIST = ['bookmark', 'tab', 'history', 'search', 'customSearch', 'direct']
 
 /**
@@ -75,7 +73,6 @@ export async function renderSearchResults() {
 
       const badges = []
       const type = entry.type || ''
-      if (entry.dupe) badges.push(BADGE_DUPLICATE)
 
       const tagsArray = entry.tagsArray
       if (opts.displayTags && tagsArray) {

--- a/popup/json/options.schema.json
+++ b/popup/json/options.schema.json
@@ -187,12 +187,6 @@
       "description": "Array of bookmark folder paths whose contents should never be indexed. All subfolders of the listed folders are skipped as well.",
       "x-ui-section": "bookmarks"
     },
-    "detectDuplicateBookmarks": {
-      "type": "boolean",
-      "default": false,
-      "description": "Detect bookmarks with identical URLs and mark them with a red 'D' badge. Useful for cleaning up duplicates.",
-      "x-ui-section": "bookmarks"
-    },
     "tabsOnlyCurrentWindow": {
       "type": "boolean",
       "default": false,


### PR DESCRIPTION
- **REMOVED**: Removed the popup `detectDuplicateBookmarks` option and duplicate result badge. Duplicate cleanup remains available in the Bookmark Manager.