### PR TITLE
Include bookmark IDs in Netscape HTML export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- **IMPROVED**: Bookmark HTML export now includes the browser bookmark `ID` on each `<A>` and `<H3>` element. The attribute is safely ignored on re-import and lets external tooling (for example AI cleanup proposal files) reference bookmarks by their real id.
+
 ## [v2.4.0] - 2026-06-27
 
 - **NEW**: Added quick bookmark and edit actions directly from search results.

--- a/popup/js/model/__tests__/bookmarkExport.test.js
+++ b/popup/js/model/__tests__/bookmarkExport.test.js
@@ -40,12 +40,36 @@ describe('bookmark export', () => {
     expect(html).toContain('<!DOCTYPE NETSCAPE-Bookmark-file-1>')
     expect(html).toContain('<H1>Bookmarks</H1>')
     expect(html).toContain(
-      '<DT><H3 ADD_DATE="1700000001" LAST_MODIFIED="1700000002" PERSONAL_TOOLBAR_FOLDER="true">Bookmarks Bar</H3>',
+      '<DT><H3 ADD_DATE="1700000001" LAST_MODIFIED="1700000002" ID="1" PERSONAL_TOOLBAR_FOLDER="true">Bookmarks Bar</H3>',
     )
     expect(html).toContain(
-      '<DT><A HREF="https://example.test/?a=1&amp;b=&lt;two&gt;" ADD_DATE="1700000003">Example &amp; Docs</A>',
+      '<DT><A HREF="https://example.test/?a=1&amp;b=&lt;two&gt;" ADD_DATE="1700000003" ID="b1">Example &amp; Docs</A>',
     )
     expect(html).not.toContain('Empty Folder')
+  })
+
+  test('omits ID attribute when bookmark or folder has no id', () => {
+    const html = createBookmarkExportHtml(
+      [
+        {
+          title: 'Anon Folder',
+          dateAdded: 1700000001,
+          dateGroupModified: 1700000002,
+          children: [
+            {
+              title: 'Anon Bookmark',
+              url: 'https://anon.test/',
+              dateAdded: 1700000003000,
+            },
+          ],
+        },
+      ],
+      1700000004000,
+    )
+
+    expect(html).toContain('<DT><H3 ADD_DATE="1700000001" LAST_MODIFIED="1700000002">Anon Folder</H3>')
+    expect(html).toContain('<DT><A HREF="https://anon.test/" ADD_DATE="1700000003">Anon Bookmark</A>')
+    expect(html).not.toMatch(/ID=""/)
   })
 
   test('creates dated html export filenames', () => {

--- a/popup/js/model/bookmarkCleanupProposal.js
+++ b/popup/js/model/bookmarkCleanupProposal.js
@@ -2,7 +2,7 @@
  * @file Prompt, schema, and validation helpers for AI bookmark cleanup proposals.
  */
 
-import { normalizeTagName } from './bookmarkManagerOperations.js'
+import { findBookmarkById, normalizeTagName } from './bookmarkManagerOperations.js'
 
 const DEFAULT_PROMPT_BOOKMARK_LIMIT = 1000
 const PROMPT_BOOKMARK_TEXT_BUDGET = 80000
@@ -504,7 +504,7 @@ export function validateBookmarkCleanupProposal(proposal, managerModel) {
     return errors
   }
 
-  const bookmarkIds = new Set((managerModel?.bookmarks || []).map((bookmark) => String(bookmark.originalId)))
+  const resolveBookmarkId = createBookmarkIdResolver(managerModel)
   const folderIds = new Set((managerModel?.folderOptions || []).map((folder) => String(folder.id)))
   const existingTags = new Set()
 
@@ -512,14 +512,32 @@ export function validateBookmarkCleanupProposal(proposal, managerModel) {
     existingTags.add(group.name.toLowerCase())
   }
 
-  validateTagChanges(errors, changes.addTags, 'addTags', bookmarkIds)
-  validateTagChanges(errors, changes.removeTags, 'removeTags', bookmarkIds)
-  validateRenameTagChanges(errors, changes.renameTags, existingTags, bookmarkIds)
-  validateMoveChanges(errors, changes.moveBookmarks, bookmarkIds, folderIds)
-  validateDeleteChanges(errors, changes.deleteBookmarks, bookmarkIds, managerModel)
-  validateRewriteTitleChanges(errors, changes.rewriteTitles, bookmarkIds)
+  validateTagChanges(errors, changes.addTags, 'addTags', resolveBookmarkId)
+  validateTagChanges(errors, changes.removeTags, 'removeTags', resolveBookmarkId)
+  validateRenameTagChanges(errors, changes.renameTags, existingTags, resolveBookmarkId)
+  validateMoveChanges(errors, changes.moveBookmarks, resolveBookmarkId, folderIds)
+  validateDeleteChanges(errors, changes.deleteBookmarks, resolveBookmarkId, managerModel)
+  validateRewriteTitleChanges(errors, changes.rewriteTitles, resolveBookmarkId)
 
   return errors
+}
+
+/**
+ * Build a resolver that maps a proposal's bookmarkId to the real originalId.
+ * Returns "" when the value is missing or does not match a known bookmark.
+ *
+ * @param {Object} managerModel Bookmark manager model.
+ * @returns {(value: unknown) => string}
+ */
+function createBookmarkIdResolver(managerModel) {
+  const bookmarks = managerModel?.bookmarks || []
+  return (value) => {
+    if (value == null || value === '') {
+      return ''
+    }
+    const bookmark = findBookmarkById(bookmarks, value)
+    return bookmark ? String(bookmark.originalId) : ''
+  }
 }
 
 /**
@@ -587,7 +605,7 @@ function formatBookmarkForPrompt(bookmark) {
   ].join(' | ')
 }
 
-function validateTagChanges(errors, changes, name, bookmarkIds) {
+function validateTagChanges(errors, changes, name, resolveBookmarkId) {
   if (typeof changes === 'undefined') {
     return
   }
@@ -599,7 +617,7 @@ function validateTagChanges(errors, changes, name, bookmarkIds) {
   for (let i = 0; i < changes.length; i++) {
     const change = changes[i]
     validateChangeBase(errors, change, name, i)
-    if (!bookmarkIds.has(String(change?.bookmarkId))) {
+    if (!resolveBookmarkId(change?.bookmarkId)) {
       errors.push(`changes.${name}[${i}].bookmarkId does not match an existing bookmark.`)
     }
     if (!Array.isArray(change?.tags) || !change.tags.length) {
@@ -608,7 +626,7 @@ function validateTagChanges(errors, changes, name, bookmarkIds) {
   }
 }
 
-function validateRenameTagChanges(errors, changes, existingTags, bookmarkIds) {
+function validateRenameTagChanges(errors, changes, existingTags, resolveBookmarkId) {
   if (typeof changes === 'undefined') {
     return
   }
@@ -628,7 +646,7 @@ function validateRenameTagChanges(errors, changes, existingTags, bookmarkIds) {
     }
     if (Array.isArray(change?.bookmarkIds)) {
       for (let j = 0; j < change.bookmarkIds.length; j++) {
-        if (!bookmarkIds.has(String(change.bookmarkIds[j]))) {
+        if (!resolveBookmarkId(change.bookmarkIds[j])) {
           errors.push(`changes.renameTags[${i}].bookmarkIds[${j}] does not match an existing bookmark.`)
         }
       }
@@ -636,7 +654,7 @@ function validateRenameTagChanges(errors, changes, existingTags, bookmarkIds) {
   }
 }
 
-function validateMoveChanges(errors, changes, bookmarkIds, folderIds) {
+function validateMoveChanges(errors, changes, resolveBookmarkId, folderIds) {
   if (typeof changes === 'undefined') {
     return
   }
@@ -648,7 +666,7 @@ function validateMoveChanges(errors, changes, bookmarkIds, folderIds) {
   for (let i = 0; i < changes.length; i++) {
     const change = changes[i]
     validateChangeBase(errors, change, 'moveBookmarks', i)
-    if (!bookmarkIds.has(String(change?.bookmarkId))) {
+    if (!resolveBookmarkId(change?.bookmarkId)) {
       errors.push(`changes.moveBookmarks[${i}].bookmarkId does not match an existing bookmark.`)
     }
     if (!folderIds.has(String(change?.targetFolderId))) {
@@ -657,7 +675,7 @@ function validateMoveChanges(errors, changes, bookmarkIds, folderIds) {
   }
 }
 
-function validateDeleteChanges(errors, changes, bookmarkIds, managerModel) {
+function validateDeleteChanges(errors, changes, resolveBookmarkId, managerModel) {
   if (typeof changes === 'undefined') {
     return
   }
@@ -669,17 +687,19 @@ function validateDeleteChanges(errors, changes, bookmarkIds, managerModel) {
   for (let i = 0; i < changes.length; i++) {
     const change = changes[i]
     validateChangeBase(errors, change, 'deleteBookmarks', i)
-    if (!bookmarkIds.has(String(change?.bookmarkId))) {
+    const resolvedBookmarkId = resolveBookmarkId(change?.bookmarkId)
+    if (!resolvedBookmarkId) {
       errors.push(`changes.deleteBookmarks[${i}].bookmarkId does not match an existing bookmark.`)
       continue
     }
-    if (!bookmarkIds.has(String(change?.duplicateOfBookmarkId))) {
+    const resolvedDuplicateId = resolveBookmarkId(change?.duplicateOfBookmarkId)
+    if (!resolvedDuplicateId) {
       errors.push(`changes.deleteBookmarks[${i}].duplicateOfBookmarkId does not match an existing bookmark.`)
       continue
     }
-    if (String(change?.bookmarkId) === String(change?.duplicateOfBookmarkId)) {
+    if (resolvedBookmarkId === resolvedDuplicateId) {
       errors.push(`changes.deleteBookmarks[${i}] cannot delete and keep the same bookmark.`)
-    } else if (!isDuplicateBookmarkPair(change?.bookmarkId, change?.duplicateOfBookmarkId, managerModel)) {
+    } else if (!isDuplicateBookmarkPair(resolvedBookmarkId, resolvedDuplicateId, managerModel)) {
       errors.push(`changes.deleteBookmarks[${i}] must reference bookmarks from the same duplicate URL group.`)
     }
   }
@@ -687,7 +707,7 @@ function validateDeleteChanges(errors, changes, bookmarkIds, managerModel) {
   validateDeleteChangesLeaveDuplicateSurvivors(errors, changes, managerModel)
 }
 
-function validateRewriteTitleChanges(errors, changes, bookmarkIds) {
+function validateRewriteTitleChanges(errors, changes, resolveBookmarkId) {
   if (typeof changes === 'undefined') {
     return
   }
@@ -699,7 +719,7 @@ function validateRewriteTitleChanges(errors, changes, bookmarkIds) {
   for (let i = 0; i < changes.length; i++) {
     const change = changes[i]
     validateChangeBase(errors, change, 'rewriteTitles', i)
-    if (!bookmarkIds.has(String(change?.bookmarkId))) {
+    if (!resolveBookmarkId(change?.bookmarkId)) {
       errors.push(`changes.rewriteTitles[${i}].bookmarkId does not match an existing bookmark.`)
     }
     if (!normalizePromptTitle(change?.title)) {
@@ -755,7 +775,7 @@ function normalizeBookmarkCleanupProposal(proposal) {
 }
 
 function normalizeBookmarkCleanupProposalWithIssues(proposal, managerModel, warnings) {
-  const bookmarkIds = new Set((managerModel?.bookmarks || []).map((bookmark) => String(bookmark.originalId)))
+  const resolveBookmarkId = createBookmarkIdResolver(managerModel)
   const folderIds = new Set((managerModel?.folderOptions || []).map((folder) => String(folder.id)))
   const existingTags = new Set((managerModel?.tagGroups || []).map((tag) => tag.name.toLowerCase()))
   const changes = proposal.changes || {}
@@ -763,17 +783,22 @@ function normalizeBookmarkCleanupProposalWithIssues(proposal, managerModel, warn
   return {
     summary: String(proposal.summary || '').trim(),
     changes: {
-      addTags: normalizeTagChangesWithIssues(changes.addTags, 'addTags', bookmarkIds, warnings),
-      removeTags: normalizeTagChangesWithIssues(changes.removeTags, 'removeTags', bookmarkIds, warnings),
-      renameTags: normalizeRenameTagChangesWithIssues(changes.renameTags, existingTags, bookmarkIds, warnings),
-      moveBookmarks: normalizeMoveChangesWithIssues(changes.moveBookmarks, bookmarkIds, folderIds, warnings),
-      deleteBookmarks: normalizeDeleteChangesWithIssues(changes.deleteBookmarks, bookmarkIds, managerModel, warnings),
-      rewriteTitles: normalizeRewriteTitleChangesWithIssues(changes.rewriteTitles, bookmarkIds, warnings),
+      addTags: normalizeTagChangesWithIssues(changes.addTags, 'addTags', resolveBookmarkId, warnings),
+      removeTags: normalizeTagChangesWithIssues(changes.removeTags, 'removeTags', resolveBookmarkId, warnings),
+      renameTags: normalizeRenameTagChangesWithIssues(changes.renameTags, existingTags, resolveBookmarkId, warnings),
+      moveBookmarks: normalizeMoveChangesWithIssues(changes.moveBookmarks, resolveBookmarkId, folderIds, warnings),
+      deleteBookmarks: normalizeDeleteChangesWithIssues(
+        changes.deleteBookmarks,
+        resolveBookmarkId,
+        managerModel,
+        warnings,
+      ),
+      rewriteTitles: normalizeRewriteTitleChangesWithIssues(changes.rewriteTitles, resolveBookmarkId, warnings),
     },
   }
 }
 
-function normalizeTagChangesWithIssues(changes, name, bookmarkIds, warnings) {
+function normalizeTagChangesWithIssues(changes, name, resolveBookmarkId, warnings) {
   if (typeof changes === 'undefined') {
     return []
   }
@@ -790,10 +815,11 @@ function normalizeTagChangesWithIssues(changes, name, bookmarkIds, warnings) {
       continue
     }
 
-    const bookmarkId = String(change.bookmarkId || '')
+    const rawBookmarkId = String(change.bookmarkId || '')
+    const resolvedBookmarkId = resolveBookmarkId(change.bookmarkId)
     const tags = Array.isArray(change.tags) ? normalizePromptTags(change.tags) : []
-    if (!bookmarkIds.has(bookmarkId)) {
-      warnings.push(`${context} ignored because bookmarkId "${bookmarkId || 'missing'}" does not exist.`)
+    if (!resolvedBookmarkId) {
+      warnings.push(`${context} ignored because bookmarkId "${rawBookmarkId || 'missing'}" does not exist.`)
       continue
     }
     if (!tags.length) {
@@ -803,7 +829,7 @@ function normalizeTagChangesWithIssues(changes, name, bookmarkIds, warnings) {
 
     result.push({
       id: normalizeChangeId(change.id, name, i),
-      bookmarkId,
+      bookmarkId: resolvedBookmarkId,
       tags,
       reason: String(change.reason || '').trim(),
     })
@@ -812,7 +838,7 @@ function normalizeTagChangesWithIssues(changes, name, bookmarkIds, warnings) {
   return result
 }
 
-function normalizeRenameTagChangesWithIssues(changes, existingTags, bookmarkIds, warnings) {
+function normalizeRenameTagChangesWithIssues(changes, existingTags, resolveBookmarkId, warnings) {
   if (typeof changes === 'undefined') {
     return []
   }
@@ -844,7 +870,7 @@ function normalizeRenameTagChangesWithIssues(changes, existingTags, bookmarkIds,
       id: normalizeChangeId(change.id, 'renameTags', i),
       from,
       to,
-      bookmarkIds: normalizeOptionalBookmarkIds(change.bookmarkIds, bookmarkIds, context, warnings),
+      bookmarkIds: normalizeOptionalBookmarkIds(change.bookmarkIds, resolveBookmarkId, context, warnings),
       reason: String(change.reason || '').trim(),
     })
   }
@@ -852,7 +878,7 @@ function normalizeRenameTagChangesWithIssues(changes, existingTags, bookmarkIds,
   return result
 }
 
-function normalizeMoveChangesWithIssues(changes, bookmarkIds, folderIds, warnings) {
+function normalizeMoveChangesWithIssues(changes, resolveBookmarkId, folderIds, warnings) {
   if (typeof changes === 'undefined') {
     return []
   }
@@ -869,10 +895,11 @@ function normalizeMoveChangesWithIssues(changes, bookmarkIds, folderIds, warning
       continue
     }
 
-    const bookmarkId = String(change.bookmarkId || '')
+    const rawBookmarkId = String(change.bookmarkId || '')
+    const resolvedBookmarkId = resolveBookmarkId(change.bookmarkId)
     const targetFolderId = String(change.targetFolderId || '')
-    if (!bookmarkIds.has(bookmarkId)) {
-      warnings.push(`${context} ignored because bookmarkId "${bookmarkId || 'missing'}" does not exist.`)
+    if (!resolvedBookmarkId) {
+      warnings.push(`${context} ignored because bookmarkId "${rawBookmarkId || 'missing'}" does not exist.`)
       continue
     }
     if (!folderIds.has(targetFolderId)) {
@@ -882,7 +909,7 @@ function normalizeMoveChangesWithIssues(changes, bookmarkIds, folderIds, warning
 
     result.push({
       id: normalizeChangeId(change.id, 'moveBookmarks', i),
-      bookmarkId,
+      bookmarkId: resolvedBookmarkId,
       targetFolderId,
       targetFolderPath: String(change.targetFolderPath || '').trim(),
       reason: String(change.reason || '').trim(),
@@ -892,7 +919,7 @@ function normalizeMoveChangesWithIssues(changes, bookmarkIds, folderIds, warning
   return result
 }
 
-function normalizeDeleteChangesWithIssues(changes, bookmarkIds, managerModel, warnings) {
+function normalizeDeleteChangesWithIssues(changes, resolveBookmarkId, managerModel, warnings) {
   if (typeof changes === 'undefined') {
     return []
   }
@@ -909,16 +936,16 @@ function normalizeDeleteChangesWithIssues(changes, bookmarkIds, managerModel, wa
       continue
     }
 
-    const bookmarkId = String(change.bookmarkId || '')
-    const duplicateOfBookmarkId = String(change.duplicateOfBookmarkId || '')
-    if (!bookmarkIds.has(bookmarkId)) {
-      warnings.push(`${context} ignored because bookmarkId "${bookmarkId || 'missing'}" does not exist.`)
+    const rawBookmarkId = String(change.bookmarkId || '')
+    const rawDuplicateId = String(change.duplicateOfBookmarkId || '')
+    const bookmarkId = resolveBookmarkId(change.bookmarkId)
+    const duplicateOfBookmarkId = resolveBookmarkId(change.duplicateOfBookmarkId)
+    if (!bookmarkId) {
+      warnings.push(`${context} ignored because bookmarkId "${rawBookmarkId || 'missing'}" does not exist.`)
       continue
     }
-    if (!bookmarkIds.has(duplicateOfBookmarkId)) {
-      warnings.push(
-        `${context} ignored because duplicateOfBookmarkId "${duplicateOfBookmarkId || 'missing'}" does not exist.`,
-      )
+    if (!duplicateOfBookmarkId) {
+      warnings.push(`${context} ignored because duplicateOfBookmarkId "${rawDuplicateId || 'missing'}" does not exist.`)
       continue
     }
     if (bookmarkId === duplicateOfBookmarkId) {
@@ -941,7 +968,7 @@ function normalizeDeleteChangesWithIssues(changes, bookmarkIds, managerModel, wa
   return removeUnsafeDuplicateGroupDeletes(result, managerModel, warnings)
 }
 
-function normalizeRewriteTitleChangesWithIssues(changes, bookmarkIds, warnings) {
+function normalizeRewriteTitleChangesWithIssues(changes, resolveBookmarkId, warnings) {
   if (typeof changes === 'undefined') {
     return []
   }
@@ -958,10 +985,11 @@ function normalizeRewriteTitleChangesWithIssues(changes, bookmarkIds, warnings) 
       continue
     }
 
-    const bookmarkId = String(change.bookmarkId || '')
+    const rawBookmarkId = String(change.bookmarkId || '')
+    const resolvedBookmarkId = resolveBookmarkId(change.bookmarkId)
     const title = normalizePromptTitle(change.title)
-    if (!bookmarkIds.has(bookmarkId)) {
-      warnings.push(`${context} ignored because bookmarkId "${bookmarkId || 'missing'}" does not exist.`)
+    if (!resolvedBookmarkId) {
+      warnings.push(`${context} ignored because bookmarkId "${rawBookmarkId || 'missing'}" does not exist.`)
       continue
     }
     if (!title) {
@@ -971,7 +999,7 @@ function normalizeRewriteTitleChangesWithIssues(changes, bookmarkIds, warnings) 
 
     result.push({
       id: normalizeChangeId(change.id, 'rewriteTitles', i),
-      bookmarkId,
+      bookmarkId: resolvedBookmarkId,
       title,
       reason: String(change.reason || '').trim(),
     })
@@ -980,18 +1008,19 @@ function normalizeRewriteTitleChangesWithIssues(changes, bookmarkIds, warnings) 
   return result
 }
 
-function normalizeOptionalBookmarkIds(bookmarkIds, knownBookmarkIds, context, warnings) {
+function normalizeOptionalBookmarkIds(bookmarkIds, resolveBookmarkId, context, warnings) {
   if (!Array.isArray(bookmarkIds)) {
     return []
   }
 
   const result = []
   for (let i = 0; i < bookmarkIds.length; i++) {
-    const bookmarkId = String(bookmarkIds[i])
-    if (knownBookmarkIds.has(bookmarkId)) {
-      result.push(bookmarkId)
+    const rawBookmarkId = String(bookmarkIds[i])
+    const resolved = resolveBookmarkId(bookmarkIds[i])
+    if (resolved) {
+      result.push(resolved)
     } else {
-      warnings.push(`${context}.bookmarkIds[${i}] ignored because bookmark "${bookmarkId}" does not exist.`)
+      warnings.push(`${context}.bookmarkIds[${i}] ignored because bookmark "${rawBookmarkId}" does not exist.`)
     }
   }
   return result

--- a/popup/js/model/bookmarkExport.js
+++ b/popup/js/model/bookmarkExport.js
@@ -78,6 +78,10 @@ function appendFolder(lines, folder, depth, fallbackDate) {
   const modifiedDate = toUnixSeconds(folder.dateGroupModified, addDate)
   const title = escapeBookmarkHtml(folder.title || 'Bookmarks')
   const attributes = [`ADD_DATE="${addDate}"`, `LAST_MODIFIED="${modifiedDate}"`]
+  const id = folder.id != null && folder.id !== '' ? String(folder.id) : ''
+  if (id) {
+    attributes.push(`ID="${escapeBookmarkHtml(id)}"`)
+  }
 
   if (depth === 1 && isBookmarksBarFolder(folder)) {
     attributes.push('PERSONAL_TOOLBAR_FOLDER="true"')
@@ -99,8 +103,10 @@ function appendBookmark(lines, bookmark, depth, fallbackDate) {
   const addDate = toUnixSeconds(bookmark.dateAdded, fallbackDate)
   const url = escapeBookmarkHtml(bookmark.url)
   const title = escapeBookmarkHtml(bookmark.title || bookmark.url)
+  const id = bookmark.id != null && bookmark.id !== '' ? String(bookmark.id) : ''
+  const idAttr = id ? ` ID="${escapeBookmarkHtml(id)}"` : ''
 
-  lines.push(`${indent}<DT><A HREF="${url}" ADD_DATE="${addDate}">${title}</A>`)
+  lines.push(`${indent}<DT><A HREF="${url}" ADD_DATE="${addDate}"${idAttr}>${title}</A>`)
 }
 
 function isBookmarksBarFolder(folder) {


### PR DESCRIPTION
Adds `ID="..."` on `<A>` and `<H3>` elements when the browser bookmark id is available so proposal files authored against an export can reference bookmarks by their real originalId. The attribute is dropped when no id is present, keeping older callers unchanged. Browsers ignore unknown attributes on Netscape bookmark HTML import, so exports remain round-trippable.

Also refactors the cleanup proposal validator to a small resolver that maps bookmarkId values to real originalIds, so future changes to id lookup have one seam.