### PR TITLE
Deduplicate concurrent lazy script loads

### DIFF
--- a/popup/js/helper/__tests__/utils.test.js
+++ b/popup/js/helper/__tests__/utils.test.js
@@ -205,7 +205,7 @@ describe('loadScript', () => {
     expect(mockHead.appendChild).not.toHaveBeenCalled()
   })
 
-  it.failing('deduplicates concurrent loads for the same script while the first request is still pending', () => {
+  it('deduplicates concurrent loads for the same script while the first request is still pending', async () => {
     const url = 'https://example.com/concurrent.js'
     const createdScripts = []
 
@@ -220,11 +220,15 @@ describe('loadScript', () => {
       return script
     })
 
-    loadScript(url)
-    loadScript(url)
+    const firstLoad = loadScript(url)
+    const secondLoad = loadScript(url)
 
+    expect(secondLoad).toBe(firstLoad)
     expect(document.createElement).toHaveBeenCalledTimes(1)
     expect(mockHead.appendChild).toHaveBeenCalledTimes(1)
+
+    createdScripts[0].onload()
+    await expect(Promise.all([firstLoad, secondLoad])).resolves.toEqual([undefined, undefined])
   })
 
   it('rejects when script fails to load and retries create element on next call', async () => {

--- a/popup/js/helper/utils.js
+++ b/popup/js/helper/utils.js
@@ -190,8 +190,8 @@ export function cleanUpUrl(url) {
   return start === 0 && end === normalizedUrl.length ? normalizedUrl : normalizedUrl.slice(start, end)
 }
 
-// Cache for loaded scripts to avoid duplicate loading and network requests
-const loadedScripts = new Set()
+// Cache script load promises to deduplicate both completed and in-flight requests
+const scriptLoads = new Map()
 
 /**
  * Dynamically loads a script file and caches the result
@@ -204,22 +204,34 @@ const loadedScripts = new Set()
  * @returns {Promise<void>} Resolves when script is loaded or cached
  * @throws {Error} If script fails to load
  */
-export async function loadScript(url) {
-  if (loadedScripts.has(url)) {
-    return Promise.resolve()
+export function loadScript(url) {
+  const cachedLoad = scriptLoads.get(url)
+  if (cachedLoad) {
+    return cachedLoad
   }
 
-  return new Promise((resolve, reject) => {
-    const s = document.createElement('script')
-    s.type = 'text/javascript'
-    s.onload = () => {
-      loadedScripts.add(url)
-      resolve()
-    }
+  const s = document.createElement('script')
+  s.type = 'text/javascript'
+  s.src = url
+
+  let rejectLoad
+  const load = new Promise((resolve, reject) => {
+    rejectLoad = reject
+    s.onload = () => resolve()
     s.onerror = () => {
+      scriptLoads.delete(url)
       reject(new Error(`Failed to load script: ${url}`))
     }
-    s.src = url
-    document.getElementsByTagName('head')[0].appendChild(s)
   })
+
+  scriptLoads.set(url, load)
+
+  try {
+    document.getElementsByTagName('head')[0].appendChild(s)
+  } catch (error) {
+    scriptLoads.delete(url)
+    rejectLoad(error)
+  }
+
+  return load
 }


### PR DESCRIPTION
## Summary
- cache the in-flight script promise as well as completed loads
- evict failed loads so later calls can retry
- turn the existing failing concurrency regression into a passing assertion

## Why
Rapid fuzzy searches can request uFuzzy before its first load completes. Previously each call appended another script tag; sharing one promise avoids duplicate loading work and keeps all callers synchronized.

## Verification
- npm run test:ci (606 unit tests, 71 Chromium E2E tests)
- npm run test:perf:full (no performance regressions)