### PR TITLE
Keep search data when browser APIs fail

### DIFF
--- a/popup/js/helper/__tests__/browserApi.test.js
+++ b/popup/js/helper/__tests__/browserApi.test.js
@@ -5,6 +5,8 @@ import {
   convertBrowserHistory,
   convertBrowserTabs,
   createSearchStringLower,
+  getBrowserBookmarks,
+  getBrowserHistory,
   getBrowserTabGroups,
   getBrowserTabs,
   getTitle,
@@ -26,6 +28,9 @@ afterEach(() => {
   delete globalThis.ext
   jest.restoreAllMocks()
   delete browserApi.tabs
+  delete browserApi.bookmarks
+  delete browserApi.history
+  delete browserApi.tabGroups
 })
 
 describe('getBrowserTabs', () => {
@@ -47,6 +52,34 @@ describe('getBrowserTabs', () => {
     expect(result[0]).toMatchObject({ id: 3, url: 'chrome-extension://abcdef' })
     expect(result[1]).toMatchObject({ id: 4, url: 'https://example.com' })
     expect(result[2]).toMatchObject({ id: 5, url: 'moz-extension://xyz' })
+  })
+
+  it('warns and returns no results when the API rejects', async () => {
+    browserApi.tabs = { query: jest.fn().mockRejectedValue(new Error('permission denied')) }
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await expect(getBrowserTabs()).resolves.toEqual([])
+    expect(warnSpy).toHaveBeenCalledWith('Error fetching tabs: permission denied')
+  })
+})
+
+describe('getBrowserBookmarks', () => {
+  it('warns and returns no results when the API rejects', async () => {
+    browserApi.bookmarks = { getTree: jest.fn().mockRejectedValue(new Error('permission denied')) }
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await expect(getBrowserBookmarks()).resolves.toEqual([])
+    expect(warnSpy).toHaveBeenCalledWith('Error fetching bookmarks: permission denied')
+  })
+})
+
+describe('getBrowserHistory', () => {
+  it('warns and returns no results when the API rejects', async () => {
+    browserApi.history = { search: jest.fn().mockRejectedValue(new Error('permission denied')) }
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await expect(getBrowserHistory(100, 20)).resolves.toEqual([])
+    expect(warnSpy).toHaveBeenCalledWith('Error fetching history: permission denied')
   })
 })
 

--- a/popup/js/helper/browserApi.js
+++ b/popup/js/helper/browserApi.js
@@ -52,10 +52,15 @@ export async function getBrowserTabs(queryOptions = {}) {
     queryOptions.currentWindow = true
   }
   if (browserApi.tabs) {
-    return (await browserApi.tabs.query(queryOptions)).filter((el) => {
-      const url = typeof el?.url === 'string' ? el.url : ''
-      return !!url.trim()
-    })
+    try {
+      return (await browserApi.tabs.query(queryOptions)).filter((el) => {
+        const url = typeof el?.url === 'string' ? el.url : ''
+        return !!url.trim()
+      })
+    } catch (err) {
+      console.warn(`Error fetching tabs: ${err.message}`)
+      return []
+    }
   } else {
     console.warn(`No browser tab API found. Returning no results.`)
     return []
@@ -129,7 +134,12 @@ export function convertBrowserTabs(chromeTabs, groupMap) {
  */
 export async function getBrowserBookmarks() {
   if (browserApi.bookmarks?.getTree) {
-    return browserApi.bookmarks.getTree()
+    try {
+      return await browserApi.bookmarks.getTree()
+    } catch (err) {
+      console.warn(`Error fetching bookmarks: ${err.message}`)
+      return []
+    }
   } else {
     console.warn(`No browser bookmark API found. Returning no results.`)
     return []
@@ -298,11 +308,16 @@ export function convertBrowserBookmarks(
  */
 export async function getBrowserHistory(startTime, maxResults) {
   if (browserApi.history) {
-    return await browserApi.history.search({
-      text: '',
-      startTime: startTime,
-      maxResults: maxResults,
-    })
+    try {
+      return await browserApi.history.search({
+        text: '',
+        startTime: startTime,
+        maxResults: maxResults,
+      })
+    } catch (err) {
+      console.warn(`Error fetching history: ${err.message}`)
+      return []
+    }
   } else {
     console.warn(`No browser history API found. Returning no results.`)
     return []

--- a/popup/js/model/__tests__/searchData.test.js
+++ b/popup/js/model/__tests__/searchData.test.js
@@ -370,7 +370,7 @@ describe('getSearchData', () => {
     }
   })
 
-  test.failing('uses the available live APIs when history is unavailable but history search is disabled', async () => {
+  test('uses the available live APIs when history is unavailable but history search is disabled', async () => {
     ext.opts.enableHistory = false
     setBrowserApiAvailability({ tabs: true, bookmarks: true, history: false, tabGroups: true })
 
@@ -418,6 +418,28 @@ describe('getSearchData', () => {
     expect(bookmarksGetTreeMock).toHaveBeenCalled()
     expect(result.tabs).toEqual(actualConvertBrowserTabs(mockState.tabs))
     expect(result.bookmarks).toEqual(actualConvertBrowserBookmarks(mockState.bookmarks))
+  })
+
+  test('keeps data from healthy browser APIs when another source rejects', async () => {
+    setBrowserData({
+      tabs: [
+        {
+          url: 'https://tab-only.com',
+          title: 'Healthy Tab',
+          id: 'tab-1',
+          active: true,
+          windowId: 2,
+        },
+      ],
+    })
+    bookmarksGetTreeMock.mockRejectedValue(new Error('bookmarks unavailable'))
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const result = await getSearchData()
+
+    expect(result.tabs).toEqual(actualConvertBrowserTabs(mockState.tabs))
+    expect(result.bookmarks).toEqual([])
+    expect(warnSpy).toHaveBeenCalledWith('Error fetching bookmarks: bookmarks unavailable')
   })
 
   test('handles mock data fetch failures gracefully', async () => {

--- a/popup/js/model/searchData.js
+++ b/popup/js/model/searchData.js
@@ -111,7 +111,7 @@ export async function getSearchData() {
   }
 
   // Use mock data (for localhost preview / development)
-  if (!browserApi.bookmarks || !browserApi.history) {
+  if (!browserApi.tabs && !browserApi.bookmarks && !browserApi.history) {
     console.warn(`No Chrome API found. Switching to local dev mode with mock data only`)
     try {
       const requestChromeMockData = await fetch('./mockData/chrome.json')


### PR DESCRIPTION
## Summary
- use available live search APIs even when another API is absent
- warn and return an empty source when tabs, bookmarks, or history rejects
- add regression coverage for missing and failed sources

## Why
A disabled or temporarily failing source should not force mock data or discard healthy results. Isolating each source preserves the data the browser can still provide and matches the project failure policy.

## Verification
- npm run test:ci (610 unit, 71 Chromium E2E)
- npm run test:perf:full (no regressions; startup 12.45 ms vs 12.11 ms baseline)