### PR TITLE
Remove unknown nested options

### DIFF
--- a/popup/js/view/__tests__/editOptionsView.test.js
+++ b/popup/js/view/__tests__/editOptionsView.test.js
@@ -424,7 +424,7 @@ describe('editOptionsView', () => {
     expect(document.getElementById('config').value).toBe('knownKey: value')
   })
 
-  it.failing('REMOVE UNKNOWN OPTIONS also strips nested unknown properties', async () => {
+  it('REMOVE UNKNOWN OPTIONS also strips nested unknown properties', async () => {
     setupDom()
     const nestedOptions = {
       customSearchEngines: [
@@ -435,6 +435,9 @@ describe('editOptionsView', () => {
           extra: 'remove-me',
         },
       ],
+      uFuzzyOptions: {
+        intraMode: 1,
+      },
     }
 
     const { module } = await loadEditOptionsView({
@@ -461,7 +464,9 @@ describe('editOptionsView', () => {
     btnClean.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     await Promise.resolve()
 
-    expect(document.getElementById('config').value).not.toContain('remove-me')
+    const cleanedOptions = JSON.parse(document.getElementById('config').value)
+    expect(cleanedOptions.customSearchEngines[0]).not.toHaveProperty('extra')
+    expect(cleanedOptions.uFuzzyOptions).toEqual({ intraMode: 1 })
   })
 
   it('shows all rows when options filter is empty', async () => {

--- a/popup/js/view/editOptionsView.js
+++ b/popup/js/view/editOptionsView.js
@@ -437,14 +437,7 @@ function removeUnknownOptions() {
     const userOptions = parseYamlValue(userOptionsString)
     if (!userOptions || typeof userOptions !== 'object') return
 
-    const schemaProperties = optionsSchema.properties || {}
-    const cleanOptions = {}
-
-    for (const [key, value] of Object.entries(userOptions)) {
-      if (key in schemaProperties || key === '$schema') {
-        cleanOptions[key] = value
-      }
-    }
+    const cleanOptions = removeUnknownProperties(userOptions, optionsSchema)
 
     setConfigYaml(cleanOptions)
     syncFormFromOptions(cleanOptions)
@@ -454,6 +447,36 @@ function removeUnknownOptions() {
     console.error('Failed to clean options:', e)
     showErrorMessage(e)
   }
+}
+
+function removeUnknownProperties(value, schema) {
+  const resolvedSchema = resolveSchemaReference(schema)
+
+  if (Array.isArray(value)) {
+    if (!resolvedSchema?.items) return value
+    return value.map((item) => removeUnknownProperties(item, resolvedSchema.items))
+  }
+
+  if (!value || typeof value !== 'object' || !resolvedSchema?.properties) {
+    return value
+  }
+
+  const cleanValue = {}
+  for (const [key, propertyValue] of Object.entries(value)) {
+    const propertySchema = resolvedSchema.properties[key]
+    if (propertySchema) {
+      cleanValue[key] = removeUnknownProperties(propertyValue, propertySchema)
+    } else if (resolvedSchema.additionalProperties !== false) {
+      cleanValue[key] = propertyValue
+    }
+  }
+  return cleanValue
+}
+
+function resolveSchemaReference(schema) {
+  if (!schema?.$ref) return schema
+  const definitionName = schema.$ref.replace('#/definitions/', '')
+  return optionsSchema.definitions?.[definitionName] || schema
 }
 
 /**


### PR DESCRIPTION
## Summary
- clean unknown properties recursively using the existing options schema
- follow array item definitions and internal schema references
- preserve objects that intentionally allow arbitrary properties

## Why
The REMOVE UNKNOWN OPTIONS action only removed root keys, so nested validation errors remained and the cleaned configuration still could not be saved. Schema-aware cleanup makes the action fulfill its UI promise without removing valid advanced settings.

## Verification
- npm run test:ci (606 unit, 71 Chromium E2E)
- npm run test:perf:full (no regressions)