### PR TITLE
Preserve search input across async navigation

### DIFF
--- a/popup/js/initSearch.js
+++ b/popup/js/initSearch.js
@@ -102,6 +102,8 @@ export async function hashRouter() {
     } else {
       // Empty search term, show default entries
       ext.dom.searchInput.value = ''
+      ext.model.searchTerm = ''
+      ext.model.rawSearchTerm = ''
       ext.dom.searchInput.focus()
       // Display default entries
       ext.model.result = await addDefaultEntries()

--- a/popup/js/search/__tests__/common.test.js
+++ b/popup/js/search/__tests__/common.test.js
@@ -374,7 +374,7 @@ describe('search', () => {
     expect(direct.title).toBe('Direct: "example.com"')
   })
 
-  test.failing('preserves the user-typed casing for direct URL navigation targets', async () => {
+  test('preserves the user-typed casing for direct URL navigation targets', async () => {
     ext.dom.searchInput.value = 'Example.com/API/Foo'
     ext.opts.enableSearchEngines = false
     ext.opts.customSearchEngines = []
@@ -384,6 +384,39 @@ describe('search', () => {
     const direct = ext.model.result.find((item) => item.type === 'direct')
     expect(direct).toBeDefined()
     expect(direct.originalUrl).toBe('https://Example.com/API/Foo')
+  })
+
+  test('keeps newer search results when an earlier empty search resolves later', async () => {
+    let resolveDefaultTabs
+    mockGetBrowserTabs.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveDefaultTabs = resolve
+        }),
+    )
+    ext.opts.enableSearchEngines = false
+    ext.opts.customSearchEngines = []
+    ext.model.bookmarks = createBookmarksTestData([
+      {
+        id: 'new-result',
+        title: 'New result',
+        url: 'https://new.test',
+      },
+    ])
+
+    ext.dom.searchInput.value = ''
+    const emptySearch = search()
+
+    ext.dom.searchInput.value = 'new'
+    await search({ key: 'n' })
+
+    resolveDefaultTabs([])
+    await emptySearch
+
+    expect(ext.model.result).toHaveLength(1)
+    expect(ext.model.result[0].originalId).toBe('new-result')
+    expect(ext.model.rawSearchTerm).toBe('new')
+    expect(mockRenderSearchResults).toHaveBeenCalledTimes(1)
   })
 
   test('keeps the newest async search results when earlier searches resolve later', async () => {

--- a/popup/js/search/__tests__/defaultResults.test.js
+++ b/popup/js/search/__tests__/defaultResults.test.js
@@ -57,7 +57,7 @@ describe('addDefaultEntries', () => {
         { id: 1, title: 'History 1', url: 'https://one.test' },
         { id: 2, title: 'History 2', url: 'https://two.test' },
       ])
-      expect(ext.model.result).toBe(results)
+      expect(ext.model.result).toBeUndefined()
     })
 
     test('clones history entries so downstream scoring cannot mutate source data', async () => {

--- a/popup/js/search/common.js
+++ b/popup/js/search/common.js
@@ -37,7 +37,7 @@ import { searchTaxonomy } from './taxonomySearch.js'
 // Export scoring function for other modules
 export { calculateFinalScore } from './scoring.js'
 
-const urlRegex = /^(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})([/\w .-]*)*\/?$/
+const urlRegex = /^(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})([/\w .-]*)*\/?$/i
 let searchRequestId = 0
 
 /**
@@ -113,9 +113,11 @@ function useCachedResultsIfAvailable(searchTerm) {
  *
  * @returns {Promise<void>}
  */
-async function handleEmptySearch() {
+async function handleEmptySearch(requestId) {
   ext.model.searchTerm = '' // Clear search term for default results
-  ext.model.result = await addDefaultEntries()
+  const results = await addDefaultEntries()
+  if (requestId !== searchRequestId) return
+  ext.model.result = results
   renderSearchResults()
 }
 
@@ -299,12 +301,14 @@ export async function search(event) {
       }
 
       // Get and clean up original search query
-      let searchTerm = normalizeSearchTerm(ext.dom.searchInput.value)
+      const rawSearchTerm = (ext.dom.searchInput.value || '').trimStart()
+      let searchTerm = normalizeSearchTerm(rawSearchTerm)
       const originalSearchTerm = searchTerm
+      ext.model.rawSearchTerm = rawSearchTerm
 
       // Handle empty search - show default results
       if (!searchTerm.trim()) {
-        await handleEmptySearch()
+        await handleEmptySearch(requestId)
         return
       }
 
@@ -313,6 +317,7 @@ export async function search(event) {
       // Parse search mode and extract term
       const { mode: detectedMode, term: trimmedTerm } = resolveSearchMode(searchTerm)
       const searchMode = detectedMode
+      const rawTrimmedTerm = rawSearchTerm.slice(searchTerm.length - trimmedTerm.length).trim()
       searchTerm = trimmedTerm.trim()
 
       ext.model.searchTerm = searchTerm
@@ -334,7 +339,7 @@ export async function search(event) {
       // Note: searchTerm can become empty after resolveSearchMode() strips mode prefix (e.g., "t ", "b ")
       if (searchTerm) {
         results.push(...(await executeSearch(searchTerm, searchMode, ext.model, ext.opts)))
-        addDirectUrlIfApplicable(searchTerm, results)
+        addDirectUrlIfApplicable(rawTrimmedTerm, results)
 
         // Add search engine result items
         if (searchMode === 'all' || searchMode === 'search') {

--- a/popup/js/search/defaultResults.js
+++ b/popup/js/search/defaultResults.js
@@ -107,7 +107,6 @@ export async function addDefaultEntries() {
     }
   }
 
-  ext.model.result = results
   return results
 }
 

--- a/popup/js/view/__tests__/searchEvents.test.js
+++ b/popup/js/view/__tests__/searchEvents.test.js
@@ -192,13 +192,14 @@ describe('searchEvents openResultItem', () => {
   it('builds the bookmark editor URL for existing bookmark results', async () => {
     const { module } = await setupSearchEvents()
     ext.model.searchTerm = 'docs query'
+    ext.model.rawSearchTerm = 'b Docs Query'
 
     const url = module.buildEditBookmarkEditorUrl({
       type: 'bookmark',
       originalId: 'folder/bookmark 1',
     })
 
-    expect(url).toBe('./editBookmark.html#bookmark/folder%2Fbookmark%201?return=%23search%2Fdocs+query')
+    expect(url).toBe('./editBookmark.html#bookmark/folder%2Fbookmark%201?return=%23search%2Fb+Docs+Query')
   })
 
   it('opens the bookmark editor for the selected bookmark', async () => {

--- a/popup/js/view/__tests__/searchView.test.js
+++ b/popup/js/view/__tests__/searchView.test.js
@@ -382,6 +382,7 @@ describe('searchView renderSearchResults', () => {
     const { module, elements } = await setupSearchView({
       results: specialResults,
     })
+    ext.model.rawSearchTerm = '#MixedCase'
 
     await module.renderSearchResults()
 
@@ -391,6 +392,7 @@ describe('searchView renderSearchResults', () => {
 
     expect(link).toContain('bookmark%2Fwith%2Fslashes')
     expect(link).not.toContain('bookmark/with/slashes')
+    expect(link).toContain('/search/%23MixedCase')
   })
 
   it('displays last-visited badge for items visited 0 seconds ago (just now)', async () => {

--- a/popup/js/view/searchEvents.js
+++ b/popup/js/view/searchEvents.js
@@ -271,7 +271,7 @@ export function buildEditBookmarkEditorUrl(result) {
 }
 
 function getSearchReturnHash() {
-  return `#search/${ext.model.searchTerm || ''}`
+  return `#search/${ext.model.rawSearchTerm ?? ext.model.searchTerm ?? ''}`
 }
 
 function getSelectedResult(event) {

--- a/popup/js/view/searchView.js
+++ b/popup/js/view/searchView.js
@@ -45,6 +45,7 @@ export async function renderSearchResults() {
     const opts = ext.opts
     const shouldHighlight = opts.displaySearchMatchHighlight
     const searchTerm = ext.model.searchTerm
+    const rawSearchTerm = ext.model.rawSearchTerm ?? searchTerm
 
     // Set up right-click context menu prevention (one-time setup)
     if (!document.hasContextMenuListener) {
@@ -56,7 +57,7 @@ export async function renderSearchResults() {
 
     // Use an array to accumulate HTML strings for all result items
     const itemsHTML = []
-    const searchTermSuffix = `/search/${encodeURIComponent(searchTerm || '')}`
+    const searchTermSuffix = `/search/${encodeURIComponent(rawSearchTerm || '')}`
 
     // Pre-calculate type-based colors once
     const typeColors = {}


### PR DESCRIPTION
## Summary
- keep the original query separate from its normalized search term
- preserve direct-URL casing and bookmark-editor return prefixes
- prevent late default results from replacing a newer search

## Why
Search normalization is useful for matching but should not change navigation targets or the query restored after editing a bookmark. Default-result generation also committed global state before the request-order guard, allowing a slower empty search to overwrite newer results.

## Verification
- npm run test:ci (607 unit, 71 Chromium E2E)
- npm run test:perf:full (no regressions; huge precise search 8.67 ms vs 8.19 ms baseline)