### PR TITLE
Prepare popup libraries for Playwright

### DIFF
--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -22,7 +22,7 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
   webServer: {
-    command: 'node bin/serveStatic.js popup 8080',
+    command: 'npm run build:update-libs && node bin/serveStatic.js popup 8080',
     url: baseURL,
     timeout: 30_000,
     reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
## Summary
- refresh generated popup libraries before Playwright starts its test server
- cover every E2E browser variant and the full performance task centrally

## Why
The generated popup libraries are gitignored, so a fresh checkout can serve 404s during E2E tests unless contributors know to run an unrelated build step first. Preparing them in Playwright makes the documented test tasks self-contained.

## Verification
- removed popup/lib, then ran a fuzzy-search E2E test successfully
- regenerated library checksums matched the originals
- npm run test:ci (606 unit, 71 Chromium E2E)
- npm run test:perf:full (no regressions)